### PR TITLE
Fix donut chart selection in wizard

### DIFF
--- a/templates/wizard.php
+++ b/templates/wizard.php
@@ -386,7 +386,7 @@
                         <div class="icon-analytics-chartDonut icon-analytics-charts-wizard"></div>
                         <div style="padding-top: 17px;">
                         <input type="radio" id="chartDonut" class="radio" name="chart" value="doughnut">
-                        <label for="chartBar"><?php p($l->t('Doughnut')); ?></label>
+                        <label for="chartDonut"><?php p($l->t('Doughnut')); ?></label>
                         </div>
                     </div>
                     <div style="display: table-cell;">


### PR DESCRIPTION
When trying to select the donut chart type in the wizard, the bar chart type actually gets selected.