### PR TITLE
Fix resource name

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 lang_map = bg_BG: bg, cs_CZ: cs, fi_FI: fi, hu_HU: hu, nb_NO: nb, sk_SK: sk, th_TH: th, ja_JP: ja
 
-[nextcloud.nextcloud-analytics]
+[nextcloud.analytics]
 file_filter = translationfiles/<lang>/analytics.po
 source_file = translationfiles/templates/analytics.pot
 source_lang = en


### PR DESCRIPTION
The resource name is now used in some translation scripts so currently analytics doesn't get translated anymore.