### PR TITLE
Fix undefined http_code variable

### DIFF
--- a/lib/Datasource/ExternalCsv.php
+++ b/lib/Datasource/ExternalCsv.php
@@ -83,6 +83,7 @@ class ExternalCsv implements IDatasource
             curl_close($ch);
         } else {
             $curlResult = '';
+            $http_code = 0;
         }
 
         $rows = str_getcsv($curlResult, "\n");


### PR DESCRIPTION
## Summary
- fix `ExternalCsv::readData()` undefined `$http_code` when curl init fails

## Testing
- `php -l lib/Datasource/ExternalCsv.php` *(fails: `php: command not found`)*