### PR TITLE
Adjust chart height when table hidden

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -325,6 +325,10 @@ content: inherit;
     padding: 10px;
 }
 
+#chartContainer.fullHeight {
+    height: 70vh;
+}
+
 #chartZoomReset {
     position: absolute;
     right: 20px;

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -797,14 +797,18 @@ OCA.Analytics.Visualization = {
     showElement: function (element) {
         if (document.getElementById(element)) {
             document.getElementById(element).hidden = false;
-            //document.getElementById(element).style.removeProperty('display');
+            if (element === 'tableContainer') {
+                document.getElementById('chartContainer').classList.remove('fullHeight');
+            }
         }
     },
 
     hideElement: function (element) {
         if (document.getElementById(element)) {
             document.getElementById(element).hidden = true;
-            //document.getElementById(element).style.display = 'none';
+            if (element === 'tableContainer') {
+                document.getElementById('chartContainer').classList.add('fullHeight');
+            }
         }
     },
 


### PR DESCRIPTION
## Summary
- expand chart to 70vh when the table is hidden
- keep default 40vh when table is visible

## Testing
- `composer` *(fails: command not found)*