### PR TITLE
Add ExternalCsv delimiter test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,8 @@
   "require": {
     "php": "^8.0",
     "phpoffice/phpspreadsheet": "^1.29.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Analytics Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/ExternalCsvTest.php
+++ b/tests/ExternalCsvTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use OCA\Analytics\Datasource\ExternalCsv;
+
+class ExternalCsvTest extends TestCase
+{
+    /**
+     * @dataProvider delimiterProvider
+     */
+    public function testDetectDelimiter(string $expected, string $line): void
+    {
+        require_once __DIR__ . '/../lib/Datasource/ExternalCsv.php';
+        $refClass = new ReflectionClass(ExternalCsv::class);
+        $instance = $refClass->newInstanceWithoutConstructor();
+        $method = $refClass->getMethod('detectDelimiter');
+        $method->setAccessible(true);
+        $result = $method->invoke($instance, $line);
+        $this->assertSame($expected, $result);
+    }
+
+    public static function delimiterProvider(): array
+    {
+        return [
+            [',', 'a,b,c'],
+            [';', 'a;b;c'],
+            ['|', 'a|b|c'],
+            ["\t", "a\tb\tc"],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit as a dev dependency
- configure PHPUnit
- test ExternalCsv::detectDelimiter with various delimiters

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `composer install` *(fails: command not found)*