### PR TITLE
Fix datasource typo in comments

### DIFF
--- a/js/advanced.js
+++ b/js/advanced.js
@@ -201,16 +201,16 @@ OCA.Analytics.Advanced.Dataload = {
                 }
                 document.getElementById('app-sidebar').dataset.dataLoadCreated = null;
 
-                // list all available datasources
+                // list all available data sources
                 OCA.Analytics.Datasource.buildDropdown('datasourceSelect');
 
-                // write dimension structure to datasource array [0] in case it is required for a deletion job later
+                // write dimension structure to data source array [0] in case it is required for a deletion job later
                 //OCA.Analytics.Advanced.Dataload.updateDatasourceDeletionOption();
             });
     },
 
     updateDatasourceDeletionOption: function () {
-        // write dimension structure to datasource array [0] in case it is required for a deletion job later
+        // write dimension structure to data source array [0] in case it is required for a deletion job later
 
         // fill Options dropdown
         let optionSelectOptions = '';
@@ -266,7 +266,7 @@ OCA.Analytics.Advanced.Dataload = {
     },
 
     buildDataloadOptions: function (evt, id = null) {
-        // write dimension structure to datasource array [0] in case it is required for a deletion job later
+        // write dimension structure to data source array [0] in case it is required for a deletion job later
         OCA.Analytics.Advanced.Dataload.updateDatasourceDeletionOption();
 
         let dataload;
@@ -289,11 +289,11 @@ OCA.Analytics.Advanced.Dataload = {
         document.getElementById('dataloadSchedule').addEventListener('change', OCA.Analytics.Advanced.Dataload.updateDataload);
         document.getElementById('dataloadOCC').innerText = 'occ analytics:load ' + dataload['id'];
 
-        // get all the options for a datasource
+        // get all the options for a data source
         document.getElementById('dataloadDetailItems').innerHTML = '';
         document.getElementById('dataloadDetailItems').appendChild(OCA.Analytics.Datasource.buildDatasourceRelatedForm(dataload['datasource']));
 
-        // set the options for a datasource
+        // set the options for a data source
         let fieldValues = JSON.parse(dataload['option']);
         for (let fieldValue in fieldValues) {
             document.getElementById(fieldValue) ? document.getElementById(fieldValue).value = OCA.Analytics.Advanced.Dataload.decodeEscapedHtml(fieldValues[fieldValue]) : null;
@@ -362,7 +362,7 @@ OCA.Analytics.Advanced.Dataload = {
         const dataloadId = parseInt(document.getElementById('dataloadDetail').dataset.dataloadId);
         let option = {};
 
-        // loop all dynamic options of the selected datasource
+        // loop all dynamic options of the selected data source
         let inputFields = document.querySelectorAll('#dataloadDetailItems input, #dataloadDetailItems select, #dataloadDetailItems textarea, #dataloadDetailDelete select');
         for (let inputField of inputFields) {
             option[inputField['id']] = inputField['value'];

--- a/js/app.js
+++ b/js/app.js
@@ -857,7 +857,7 @@ OCA.Analytics.Datasource = {
         if (filter) {
             filterDatasource = '/' + filter;
         }
-        // need to offer an await here, because the datasourceOptions is important for subsequent functions in the sidebar
+        // need to offer an await here, because the data source options are important for subsequent functions in the sidebar
         let requestUrl = OC.generateUrl('apps/analytics/datasource' + filterDatasource);
         let response = await fetch(requestUrl, {
             method: 'GET',
@@ -916,7 +916,7 @@ OCA.Analytics.Datasource = {
         form.appendChild(OCA.Analytics.Datasource.buildOptionHidden('dataSourceType', datasource));
 
         for (let templateOption of template) {
-            // loop all options of the datasource template and create the input form
+            // loop all options of the data source template and create the input form
 
             // if it is a section, we don´t need the usual labels
             if (templateOption.type === 'section') {

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -216,7 +216,7 @@ OCA.Analytics.Sidebar.Report = {
                     document.getElementById('tabContainerReport').appendChild(table);
 
                     // create the drop downs for Data source, grouping and possible data set
-                    // need to do an await here, because the datasourceOptions is important for subsequent functions
+                    // need to do an await here, because the data source options are important for subsequent functions
                     await OCA.Analytics.Datasource.buildDropdown('sidebarReportDatasource', data['type']);
                     OCA.Analytics.Sidebar.Report.buildGroupingDropdown('sidebarReportParent');
                     OCA.Analytics.Sidebar.Report.buildDatasetDropdown('sidebarReportDataset');
@@ -280,7 +280,7 @@ OCA.Analytics.Sidebar.Report = {
     },
 
     fillDatasourceRelatedFields: function (data) {
-        // set the options for a datasource
+        // set the options for a data source
         if (data['link'] && data['link'].substring(0, 1) === '{') { // New format as of 3.1.0
             let options = JSON.parse(data['link']);
             for (let option in options) {

--- a/lib/Controller/DataloadController.php
+++ b/lib/Controller/DataloadController.php
@@ -115,7 +115,7 @@ class DataloadController extends Controller
     }
 
     /**
-     * execute a dataload from datasource and store into dataset
+     * execute a dataload from data source and store into dataset
      *
      * @NoAdminRequired
      * @param int $dataloadId

--- a/lib/Controller/DatasourceController.php
+++ b/lib/Controller/DatasourceController.php
@@ -129,7 +129,7 @@ class DatasourceController extends Controller {
 	}
 
 	/**
-	 * Get the data from a datasource;
+     * Get the data from a data source;
 	 *
 	 * @NoAdminRequired
 	 * @param int $datasourceId

--- a/lib/Datasource/ExternalCsv.php
+++ b/lib/Datasource/ExternalCsv.php
@@ -33,7 +33,7 @@ class ExternalCsv implements IDatasource
     }
 
     /**
-     * @return string Display Name of the datasource
+     * @return string Display Name of the data source
      */
     public function getName(): string
     {
@@ -49,7 +49,7 @@ class ExternalCsv implements IDatasource
     }
 
     /**
-     * @return array available options of the datasoure
+     * @return array available options of the data source
      */
     public function getTemplate(): array
     {
@@ -64,7 +64,7 @@ class ExternalCsv implements IDatasource
     /**
      * Read the Data
      * @param $option
-     * @return array available options of the datasoure
+     * @return array available options of the data source
      */
     public function readData($option): array
     {

--- a/lib/Datasource/ExternalJson.php
+++ b/lib/Datasource/ExternalJson.php
@@ -26,7 +26,7 @@ class ExternalJson implements IDatasource
     }
 
     /**
-     * @return string Display Name of the datasource
+     * @return string Display Name of the data source
      */
     public function getName(): string
     {
@@ -34,7 +34,7 @@ class ExternalJson implements IDatasource
     }
 
     /**
-     * @return int digit unique datasource id
+     * @return int digit unique data source id
      */
     public function getId(): int
     {
@@ -42,7 +42,7 @@ class ExternalJson implements IDatasource
     }
 
     /**
-     * @return array available options of the datasoure
+     * @return array available options of the data source
      */
     public function getTemplate(): array
     {
@@ -63,7 +63,7 @@ class ExternalJson implements IDatasource
     /**
      * Read the Data
      * @param $option
-     * @return array available options of the datasoure
+     * @return array available options of the data source
      */
     public function readData($option): array
     {

--- a/lib/Datasource/Github.php
+++ b/lib/Datasource/Github.php
@@ -24,21 +24,21 @@ class Github implements IDatasource {
 	}
 
 	/**
-	 * @return string Display Name of the datasource
+    * @return string Display Name of the data source
 	 */
 	public function getName(): string {
 		return 'GitHub';
 	}
 
 	/**
-	 * @return int digit unique datasource id
+    * @return int digit unique data source id
 	 */
 	public function getId(): int {
 		return 3;
 	}
 
 	/**
-	 * @return array available options of the datasource
+    * @return array available options of the data source
 	 */
 	public function getTemplate(): array {
 		$template = array();

--- a/lib/Datasource/IDatasource.php
+++ b/lib/Datasource/IDatasource.php
@@ -18,13 +18,13 @@ interface IDatasource
 {
 
     /**
-     * @return string Display Name of the datasource
+     * @return string Display Name of the data source
      * @since 3.1.0
      */
     public function getName(): string;
 
     /**
-     * @return int 2 digit unique datasource id
+     * @return int 2 digit unique data source id
      * @since 3.1.0
      */
     public function getId(): int;

--- a/lib/Datasource/LocalCsv.php
+++ b/lib/Datasource/LocalCsv.php
@@ -38,7 +38,7 @@ class LocalCsv implements IDatasource
     }
 
     /**
-     * @return string Display Name of the datasource
+     * @return string Display Name of the data source
      */
     public function getName(): string
     {
@@ -54,7 +54,7 @@ class LocalCsv implements IDatasource
     }
 
     /**
-     * @return array available options of the datasoure
+     * @return array available options of the data source
      */
     public function getTemplate(): array
     {
@@ -69,7 +69,7 @@ class LocalCsv implements IDatasource
     /**
      * Read the Data
      * @param $option
-     * @return array available options of the datasoure
+     * @return array available options of the data source
      * @throws NotFoundException
      * @throws \OCP\Files\NotPermittedException
      */

--- a/lib/Datasource/LocalJson.php
+++ b/lib/Datasource/LocalJson.php
@@ -28,21 +28,21 @@ class LocalJson implements IDatasource {
 	}
 
 	/**
-	 * @return string Display Name of the datasource
+         * @return string Display Name of the data source
 	 */
 	public function getName(): string {
 		return $this->l10n->t('Local') . ': JSON';
 	}
 
 	/**
-	 * @return int digit unique datasource id
+         * @return int digit unique data source id
 	 */
 	public function getId(): int {
 		return 2;
 	}
 
 	/**
-	 * @return array available options of the datasoure
+         * @return array available options of the data source
 	 */
 	public function getTemplate(): array {
 		$template = array();
@@ -65,7 +65,7 @@ class LocalJson implements IDatasource {
 	/**
 	 * Read the Data
 	 * @param $option
-	 * @return array available options of the data soure
+	 * @return array available options of the data source
 	 */
 	public function readData($option): array {
 		$file = $this->rootFolder->getUserFolder($option['user_id'])->get($option['link']);

--- a/lib/Datasource/LocalSpreadsheet.php
+++ b/lib/Datasource/LocalSpreadsheet.php
@@ -33,14 +33,14 @@ class LocalSpreadsheet implements IDatasource {
 	}
 
 	/**
-	 * @return string Display Name of the datasource
+         * @return string Display Name of the data source
 	 */
 	public function getName(): string {
 		return $this->l10n->t('Local') . ': Spreadsheet';
 	}
 
 	/**
-	 * @return int digit unique datasource id
+         * @return int digit unique data source id
 	 */
 	public function getId(): int {
 		return 7;

--- a/lib/Datasource/Regex.php
+++ b/lib/Datasource/Regex.php
@@ -26,7 +26,7 @@ class Regex implements IDatasource
     }
 
     /**
-     * @return string Display Name of the datasource
+     * @return string Display Name of the data source
      */
     public function getName(): string
     {
@@ -34,7 +34,7 @@ class Regex implements IDatasource
     }
 
     /**
-     * @return int digit unique datasource id
+     * @return int digit unique data source id
      */
     public function getId(): int
     {
@@ -42,7 +42,7 @@ class Regex implements IDatasource
     }
 
     /**
-     * @return array available options of the datasoure
+     * @return array available options of the data source
      */
     public function getTemplate(): array
     {
@@ -58,7 +58,7 @@ class Regex implements IDatasource
     /**
      * Read the Data
      * @param $option
-     * @return array available options of the data soure
+     * @return array available options of the data source
      */
     public function readData($option): array
     {

--- a/lib/Service/DataloadService.php
+++ b/lib/Service/DataloadService.php
@@ -166,10 +166,10 @@ class DataloadService
         $bulkInsert = null;
         $aggregation = null;
 
-        // get the data from the datasource
+        // get the data from the data source
         $result = $this->getDataFromDatasource($dataloadId);
 
-        // dont continue in case of datasource error
+        // dont continue in case of data source error
         if ($result['error'] !== 0) {
             return [
                 'insert' => $insert,
@@ -269,7 +269,7 @@ class DataloadService
     }
 
     /**
-     * get the data from datasource
+     * get the data from data source
      * to be used in simulation or execution
      *
      * @param int $dataloadId


### PR DESCRIPTION
## Summary
- correct misspellings `datasoure` -> `datasource`
- correct misspellings `data soure` -> `data source`
- switch all comment text to use wording "data source"

## Testing
- `grep -nri "datasoure" lib/Datasource`
- `grep -nri "data soure" lib/Datasource`
- `grep -nri "datasource" lib js | grep -E "//|\*"`