### PR TITLE
Add ExternalCsv delimiter test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,18 @@
   "require": {
     "php": "^8.0",
     "phpoffice/phpspreadsheet": "^1.29.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "OCA\\Analytics\\": "lib/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "OCA\\Analytics\\Tests\\": "tests/"
+    }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Analytics Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/ExternalCsvTest.php
+++ b/tests/ExternalCsvTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use OCA\Analytics\Datasource\ExternalCsv;
+use ReflectionClass;
+
+class ExternalCsvTest extends TestCase
+{
+    /**
+     * @dataProvider delimiterProvider
+     */
+    public function testDetectDelimiter(string $expected, string $line): void
+    {
+        $refClass = new ReflectionClass(ExternalCsv::class);
+        $instance = $refClass->newInstanceWithoutConstructor();
+        $method = $refClass->getMethod('detectDelimiter');
+        $method->setAccessible(true);
+        $result = $method->invoke($instance, $line);
+        $this->assertSame($expected, $result);
+    }
+
+    public static function delimiterProvider(): array
+    {
+        return [
+            [',', 'a,b,c'],
+            [';', 'a;b;c'],
+            ['|', 'a|b|c'],
+            ["\t", "a\tb\tc"],
+        ];
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+spl_autoload_register(function ($class) {
+    $prefix = 'OCA\\Analytics\\';
+    $baseDir = __DIR__ . '/../lib/';
+    $len = strlen($prefix);
+    if (strncmp($class, $prefix, $len) !== 0) {
+        return;
+    }
+    $relativeClass = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+    if (file_exists($file)) {
+        require_once $file;
+    }
+});
+


### PR DESCRIPTION
## Summary
- add PHPUnit as a dev dependency
- configure PHPUnit
- test ExternalCsv::detectDelimiter with various delimiters

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
