### PR TITLE
Refactor filter dialog to use Notification framework

### DIFF
--- a/js/filter.js
+++ b/js/filter.js
@@ -102,7 +102,7 @@ OCA.Analytics.Filter = {
         OCA.Analytics.currentReportData.options.filteroptions = filterOptions;
         OCA.Analytics.unsavedFilters = true;
         OCA.Analytics.Backend.getData();
-        OCA.Analytics.Notification.dialogClose();
+        OCA.Analytics.Filter.close();
     },
 
     openFilterDialog: function () {
@@ -146,9 +146,6 @@ OCA.Analytics.Filter = {
             }
         }
 
-        container.getElementById('filterDialogHint').addEventListener('click', OCA.Analytics.Filter.handleVariableHint);
-        container.getElementById('filterDialogCancel').addEventListener('click', OCA.Analytics.Notification.dialogClose);
-        container.getElementById('filterDialogGo').addEventListener('click', OCA.Analytics.Filter.processFilterDialog);
         container.getElementById('filterDialogValue').addEventListener('click', OCA.Analytics.UI.showDropDownList);
         container.getElementById('filterDialogValue').addEventListener('keydown', function (event) {
             if (event.key === 'Enter') {
@@ -158,12 +155,8 @@ OCA.Analytics.Filter = {
 
         OCA.Analytics.Notification.htmlDialogUpdate(
             container,
-            ''
+            t('analytics', 'Dynamic text variables can be used to select dates.<br>The selection is written between two % (e.g. %last2months%).<br>Information on available filters and alternative date formats is available in the {linkstart}Wiki{linkend}.')
         );
-    },
-
-    handleVariableHint: function () {
-        OCA.Analytics.Visualization.showElement('filterDialogHintText');
     },
 
     processFilterDialog: function () {
@@ -186,7 +179,7 @@ OCA.Analytics.Filter = {
         OCA.Analytics.currentReportData.options.filteroptions = filterOptions;
         OCA.Analytics.unsavedFilters = true;
         OCA.Analytics.Backend.getData();
-        OCA.Analytics.Filter.close();
+        OCA.Analytics.Notification.dialogClose();
     },
 
     refreshFilterVisualisation: function () {

--- a/js/filter.js
+++ b/js/filter.js
@@ -124,7 +124,7 @@ OCA.Analytics.Filter = {
             dimensionSelect.options.add(option);
         });
         dimensionSelect.addEventListener('change', function () {
-            container.getElementById('filterDialogValue').dataset.dropdownlistindex = dimensionSelect.selectedIndex;
+            document.getElementById('filterDialogValue').dataset.dropdownlistindex = dimensionSelect.selectedIndex;
         });
 
         const optionSelect = container.getElementById('filterDialogOption');

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -154,10 +154,6 @@
 </template>
 
 <template id="templateFilterDialog">
-    <span hidden id="filterDialogHintText" class="userGuidance">
-        <?php p($l->t('Dynamic text variables can be used to select dates.<br>The selection is written between two % (e.g. %last2months%).<br>Information on available filters and alternative date formats is available in the {linkstart}Wiki{linkend}.')); ?>
-        <br><br>
-    </span>
     <div class="table" style="display: table;">
         <div style="display: table-row;">
             <div style="display: table-cell; width: 80px;"></div>
@@ -170,7 +166,6 @@
             <div style="display: table-cell; width: 220px;">
                 <label for="filterDialogValue"><?php p($l->t('Value')); ?></label>
             </div>
-            <div style="display: table-cell; width: 20px;"></div>
         </div>
         <div style="display: table-row;">
             <div style="display: table-cell;">
@@ -185,17 +180,7 @@
             <div style="display: table-cell;">
                 <input type="text" id="filterDialogValue" class="optionsInputValue" autocomplete="off" data-dropDownListIndex="0">
             </div>
-            <div style="display: table-cell;">
-                <a id="filterDialogHint" title="<?php p($l->t('Variables')); ?>">
-                    <div class="icon-info" style="opacity: 0.5;padding: 0 10px;"></div>
-                </a>
-            </div>
         </div>
-    </div>
-    <br>
-    <div class="analyticsDialogButtonrow" id="buttons">
-        <a class="button primary" id="filterDialogGo"><?php p($l->t('Add')); ?></a>
-        <a class="button" id="filterDialogCancel"><?php p($l->t('Cancel')); ?></a>
     </div>
 </template>
 

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -153,6 +153,52 @@
 
 </template>
 
+<template id="templateFilterDialog">
+    <span hidden id="filterDialogHintText" class="userGuidance">
+        <?php p($l->t('Dynamic text variables can be used to select dates.<br>The selection is written between two % (e.g. %last2months%).<br>Information on available filters and alternative date formats is available in the {linkstart}Wiki{linkend}.')); ?>
+        <br><br>
+    </span>
+    <div class="table" style="display: table;">
+        <div style="display: table-row;">
+            <div style="display: table-cell; width: 80px;"></div>
+            <div style="display: table-cell; width: 150px;">
+                <label for="filterDialogDimension"><?php p($l->t('Filter by')); ?></label>
+            </div>
+            <div style="display: table-cell; width: 150px;">
+                <label for="filterDialogOption"><?php p($l->t('Operator')); ?></label>
+            </div>
+            <div style="display: table-cell; width: 220px;">
+                <label for="filterDialogValue"><?php p($l->t('Value')); ?></label>
+            </div>
+            <div style="display: table-cell; width: 20px;"></div>
+        </div>
+        <div style="display: table-row;">
+            <div style="display: table-cell;">
+                <img src="<?php echo \OC::$server->getURLGenerator()->imagePath('analytics', 'filteradd.svg'); ?>" alt="filter">
+            </div>
+            <div style="display: table-cell;">
+                <select id="filterDialogDimension" class="checkbox optionsInput"></select>
+            </div>
+            <div style="display: table-cell;">
+                <select id="filterDialogOption" class="checkbox optionsInput"></select>
+            </div>
+            <div style="display: table-cell;">
+                <input type="text" id="filterDialogValue" class="optionsInputValue" autocomplete="off" data-dropDownListIndex="0">
+            </div>
+            <div style="display: table-cell;">
+                <a id="filterDialogHint" title="<?php p($l->t('Variables')); ?>">
+                    <div class="icon-info" style="opacity: 0.5;padding: 0 10px;"></div>
+                </a>
+            </div>
+        </div>
+    </div>
+    <br>
+    <div class="analyticsDialogButtonrow" id="buttons">
+        <a class="button primary" id="filterDialogGo"><?php p($l->t('Add')); ?></a>
+        <a class="button" id="filterDialogCancel"><?php p($l->t('Cancel')); ?></a>
+    </div>
+</template>
+
 <template id="templateDataset">
     <div class="table" style="display: table; width: 100%; max-width: 500px;">
         <div style="display: table-row;">


### PR DESCRIPTION
## Summary
- add a HTML template for the filter dialog
- refactor `openFilterDialog` to use `htmlDialogInitiate` and `htmlDialogUpdate`
- close the dialog using the Notification helper

## Testing
- `npm test` *(fails: Missing script)*