### PR TITLE
Fix chart hiding with Top N

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -259,7 +259,7 @@ OCA.Analytics.Dashboard = {
         Chart.defaults.plugins.legend.display = false;
 
         // convert the data array
-        let [xAxisCategories, datasets] = OCA.Analytics.Dashboard.convertDataToChartJsFormat(jsondata.data, chartType);
+        let [xAxisCategories, datasets] = OCA.Analytics.Dashboard.convertDataToChartJsFormat(jsondata.data, chartType, jsondata.options);
 
         // do the color magic
         let colors = OCA.Analytics.Visualization.defaultColorPalette;
@@ -433,8 +433,9 @@ OCA.Analytics.Dashboard = {
         };
     },
 
-    convertDataToChartJsFormat: function (data, chartType) {
+    convertDataToChartJsFormat: function (data, chartType, options) {
         const labelMap = new Map();
+        const isTopGrouping = options?.filteroptions?.group?.type === 'top';
         let datasetCounter = 0;
         let datasets = [], xAxisCategories = [];
         data.forEach((row) => {
@@ -459,7 +460,7 @@ OCA.Analytics.Dashboard = {
                 labelMap.set(dataSeriesColumn, {
                     ...(chartType !== 'doughnut' && {label: dataSeriesColumn || undefined}), // no label for doughnut charts
                     data: [],
-                    hidden: datasetCounter >= 4 // default hide > 4th series for better visibility
+                    hidden: datasetCounter >= 4 && !isTopGrouping // default hide > 4th series for better visibility
                 });
                 datasetCounter++;
             }

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -643,6 +643,7 @@ OCA.Analytics.Visualization = {
         } else {
             // KPI-Model: Use existing logic
             const labelMap = new Map();
+            const isTopGrouping = data.options?.filteroptions?.group?.type === 'top';
             let datasetCounter = 0;
             data.forEach((row) => {
                 let dataSeriesColumn, characteristicColumn, value;
@@ -659,7 +660,7 @@ OCA.Analytics.Visualization = {
                     labelMap.set(dataSeriesColumn, {
                         ...(chartType !== 'doughnut' && {label: dataSeriesColumn || undefined}),
                         data: [],
-                        hidden: datasetCounter >= 4,
+                        hidden: datasetCounter >= 4 && !isTopGrouping,
                         yAxisID: 'primary'
                     });
                     datasetCounter++;


### PR DESCRIPTION
## Summary
- keep all datasets visible when Top N grouping is active

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*