### PR TITLE
Limit filter removal action to icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - JSON data source: remove column limit
 - Refactor filter dialog to use Notification framework #452
 - Refactor drilldown dialog to use Notification framework #462
+- UI optimization for existing filter
 
 ### Fixed
 - fix warning for importing less than 3 columns

--- a/css/print.css
+++ b/css/print.css
@@ -65,6 +65,10 @@
         padding-left: 5px !important;
     }
 
+    .filterVisualizationRemove {
+        display: none !important;
+    }
+
     /* Layout */
     @page {
         size: A4 portrait;

--- a/css/style.css
+++ b/css/style.css
@@ -668,17 +668,22 @@ div.dt-container .dt-paging .dt-paging-button {
     background-color: var(--color-background-dark);
     padding: 5px;
     border-radius: 15px;
-    padding-left: 34px;
-    background-position: 10px center;
-    background-image: var(--icon-close-dark);
-    background-repeat: no-repeat;
     opacity: .5;
     font-size: smaller;
-    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
 }
 
 .filterVisualizationItem:hover {
     opacity: 1;
+}
+
+.filterVisualizationRemove {
+    width: 16px;
+    height: 16px;
+    margin-right: 5px;
+    background: var(--icon-close-dark) no-repeat center;
+    cursor: pointer;
 }
 
 .whatsNewPopover {

--- a/js/filter.js
+++ b/js/filter.js
@@ -351,18 +351,27 @@ OCA.Analytics.Filter = {
         if (filterOptions && filterOptions["filter"]) {
             for (const filterDimension of Object.keys(filterOptions["filter"])) {
                 let optionText = OCA.Analytics.Filter.optionTextsArray[filterOptions["filter"][filterDimension]["option"]];
-                const span = document.createElement("span");
+                const container = document.createElement("span");
                 let filterValue = filterOptions["filter"][filterDimension]["value"];
                 if (filterValue.match(/%/g) && filterValue.match(/%/g).length === 2) {
                     optionText = "";
                     filterValue = filterValue.replace(/%/g, "");
                     filterValue = filterValue.replace(/\(.*?\)/g, "");
                 }
-                span.innerText = filterDimensions[filterDimension] + " " + optionText + " " + filterValue;
-                span.classList.add("filterVisualizationItem");
-                span.id = filterDimension;
-                span.addEventListener("click", OCA.Analytics.Filter.removeFilter);
-                fragment.appendChild(span);
+
+                const removeIcon = document.createElement("span");
+                removeIcon.classList.add("filterVisualizationRemove", "icon-close");
+                removeIcon.addEventListener("click", OCA.Analytics.Filter.removeFilter);
+
+                const textSpan = document.createElement("span");
+                textSpan.innerText = filterDimensions[filterDimension] + " " + optionText + " " + filterValue;
+
+                container.classList.add("filterVisualizationItem");
+                container.id = filterDimension;
+                container.appendChild(removeIcon);
+                container.appendChild(textSpan);
+
+                fragment.appendChild(container);
             }
         }
         visContainer.appendChild(fragment);
@@ -378,7 +387,8 @@ OCA.Analytics.Filter = {
      * Remove a single active filter label and reload the data.
      */
     removeFilter: function (evt) {
-        let filterDimension = evt.target.id;
+        const parent = evt.target.closest('.filterVisualizationItem');
+        let filterDimension = parent ? parent.id : evt.target.id;
         let filterOptions = OCA.Analytics.currentReportData.options.filteroptions;
         delete filterOptions['filter'][filterDimension];
         if (Object.keys(filterOptions['filter']).length === 0) {


### PR DESCRIPTION
## Summary
- split filter visualization elements into icon + text
- remove filter only when the close icon is clicked
- adapt CSS for new structure and hide icon on print

## Testing
- `npm test` *(fails: Missing script)*