### PR TITLE
Add Show All legend option

### DIFF
--- a/js/visualization.js
+++ b/js/visualization.js
@@ -518,6 +518,14 @@ OCA.Analytics.Visualization = {
             const index = legendItem.datasetIndex;
             const type = legend.chart.config.type;
 
+            if (index === -1) {
+                legend.chart.data.datasets.forEach(ds => {
+                    ds.hidden = false;
+                });
+                legend.chart.update();
+                return;
+            }
+
             // Do the original logic
             if (type === 'pie' || type === 'doughnut') {
                 pieDoughnutLegendClickHandler(e, legendItem, legend)
@@ -525,6 +533,19 @@ OCA.Analytics.Visualization = {
                 defaultLegendClickHandler(e, legendItem, legend);
             }
             document.getElementById('saveIcon')?.style.removeProperty('display');
+        };
+
+        const defaultGenerateLabels = Chart.defaults.plugins.legend.labels.generateLabels;
+        Chart.defaults.plugins.legend.labels.generateLabels = function (chart) {
+            const labels = defaultGenerateLabels(chart);
+            labels.push({
+                text: t('analytics', 'Show all'),
+                fillStyle: 'transparent',
+                strokeStyle: 'transparent',
+                hidden: false,
+                datasetIndex: -1
+            });
+            return labels;
         };
 
         this.showElement('tableSeparatorContainer');

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -251,6 +251,7 @@ OC.L10N.register(
     "If you see this message, please disable AdBlock/uBlock for this domain (only)." : "If you see this message, please disable AdBlock/uBlock for this domain (only).",
     "The EasyPrivacy list is blocking some scripts because of a wildcard filter for *analytics*." : "The EasyPrivacy list is blocking some scripts because of a wildcard filter for *analytics*.",
     "Legend" : "Legend",
+    "Show all" : "Show all",
     "No data found" : "No data found",
     "This section is used for dataset maintenance and data load configurations." : "This section is used for dataset maintenance and data load configurations.",
     "Please select a dataset" : "Please select a dataset",

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -249,6 +249,7 @@
     "If you see this message, please disable AdBlock/uBlock for this domain (only)." : "If you see this message, please disable AdBlock/uBlock for this domain (only).",
     "The EasyPrivacy list is blocking some scripts because of a wildcard filter for *analytics*." : "The EasyPrivacy list is blocking some scripts because of a wildcard filter for *analytics*.",
     "Legend" : "Legend",
+    "Show all" : "Show all",
     "No data found" : "No data found",
     "This section is used for dataset maintenance and data load configurations." : "This section is used for dataset maintenance and data load configurations.",
     "Please select a dataset" : "Please select a dataset",


### PR DESCRIPTION
## Summary
- add a custom legend item to toggle all datasets
- add English translations for the new "Show all" label

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*