### PR TITLE
Enable threshold editing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -383,6 +383,13 @@ table.dataTable tbody tr {
     height: 12px;
 }
 
+.thresholdColorIcon {
+    margin-top: 6px;
+    width: 12px;
+    height: 12px;
+    opacity: 0.7;
+}
+
 .thresholdItem {
     display: inline-flex;
     width: 100%;

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -502,8 +502,8 @@
 
     </div>
     <br>
-    <button id="sidebarThresholdCreateButton" type="button" class="primary">
-		<?php p($l->t('Save threshold')); ?>
+    <button id="sidebarThresholdCreateButton" type="button" class="primary" data-id="">
+                <?php p($l->t('Save threshold')); ?>
     </button>
     <br>
     <br>


### PR DESCRIPTION
## Summary
- allow editing thresholds by clicking an entry
- show color mode icon for each threshold
- store selected threshold id while editing

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ca6c31fcc8333ac7af97e58c8b72d