### PR TITLE
Implement threshold ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add time grouping feature #464
 - Show all button in chart legend #473
 - Support multiple rows in filter dialog #472
+- Order of thresholds can be arranged with drag & drop
 
 ### Changed
 - JSON data source: remove column limit

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ Visualize and share anything, from financial analysis to IoT logs.
 - **AI Assistant**: Context Chat integration
 
 ]]></description>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
     <licence>agpl</licence>
     <author>Marcel Scherello</author>
     <namespace>Analytics</namespace>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -108,8 +108,9 @@ return [
 
 		// Threshold
 		['name' => 'threshold#create', 'url' => '/threshold', 'verb' => 'POST'],
-		['name' => 'threshold#read', 'url' => '/threshold/{reportId}', 'verb' => 'GET'],
-		['name' => 'threshold#delete', 'url' => '/threshold/{thresholdId}', 'verb' => 'DELETE'],
+                ['name' => 'threshold#read', 'url' => '/threshold/{reportId}', 'verb' => 'GET'],
+                ['name' => 'threshold#delete', 'url' => '/threshold/{thresholdId}', 'verb' => 'DELETE'],
+                ['name' => 'threshold#reorder', 'url' => '/threshold/order/{reportId}', 'verb' => 'PUT'],
 
 		// API
 		// V1

--- a/lib/Controller/ThresholdController.php
+++ b/lib/Controller/ThresholdController.php
@@ -73,6 +73,23 @@ class ThresholdController extends Controller
     }
 
     /**
+     * Update threshold order
+     *
+     * @NoAdminRequired
+     * @param int $reportId
+     * @param array $order
+     * @return bool
+     */
+    public function reorder(int $reportId, $order): bool
+    {
+        if (is_string($order)) {
+            $order = json_decode($order, true);
+        }
+        $this->ThresholdService->reorder($order);
+        return true;
+    }
+
+    /**
      * validate threshold
      *
      * @NoAdminRequired

--- a/lib/Migration/Version5007Date20250601100000.php
+++ b/lib/Migration/Version5007Date20250601100000.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Analytics
+ *
+ * SPDX-FileCopyrightText: 2019-2022 Marcel Scherello
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Analytics\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Add sequence column to analytics_threshold
+ * sudo -u www-data php occ migrations:execute analytics 5007Date20250601100000
+ */
+class Version5007Date20250601100000 extends SimpleMigrationStep {
+    public function __construct(
+        private IDBConnection $connection,
+    ) {
+    }
+
+    /**
+     * @param IOutput $output
+     * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+     * @param array $options
+     * @return null|ISchemaWrapper
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+        /** @var ISchemaWrapper $schema */
+        $schema = $schemaClosure();
+
+        $table = $schema->getTable('analytics_threshold');
+        if (!$table->hasColumn('sequence')) {
+            $table->addColumn('sequence', 'integer', [
+                'notnull' => false,
+            ]);
+        }
+
+        return $schema;
+    }
+}

--- a/lib/Service/ThresholdService.php
+++ b/lib/Service/ThresholdService.php
@@ -99,10 +99,25 @@ class ThresholdService {
 	 * @param int $thresholdId
 	 * @return bool
 	 */
-	public function delete(int $thresholdId) {
-		$this->ThresholdMapper->deleteThreshold($thresholdId);
-		return true;
-	}
+    public function delete(int $thresholdId) {
+        $this->ThresholdMapper->deleteThreshold($thresholdId);
+        return true;
+    }
+
+    /**
+     * Update sequence of multiple thresholds
+     *
+     * @param array $orderedIds
+     * @return bool
+     */
+    public function reorder(array $orderedIds): bool {
+        $position = 1;
+        foreach ($orderedIds as $id) {
+            $this->ThresholdMapper->updateSequence((int)$id, $position);
+            $position++;
+        }
+        return true;
+    }
 
 	/**
 	 * validate notification thresholds per report


### PR DESCRIPTION
## Summary
- add `sequence` column migration for thresholds
- order thresholds by sequence and compute sequence on create
- allow reordering thresholds via new controller route
- add drag and drop UI for thresholds
- bump app version to 5.5.0 and document feature

## Testing
- `eslint -c .eslintrc.js js/sidebar.js` *(fails: config not supported)*
- `php -l lib/Controller/ThresholdController.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400e6312d88333a3e753dae9974d49