### PR TITLE
Add legend selection for reports in panoramas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - API v4 for will add %currentDate% as Y-m-d
+- Add legend selection for reports in panoramas #482
 
 ## 5.5.0 - 2025-05-26
 ### Added

--- a/js/panorama.js
+++ b/js/panorama.js
@@ -369,13 +369,18 @@ OCA.Analytics.Panorama = {
             divElement.id = `myWidget${itemId}`;
             canvasElement.parentNode.replaceChild(divElement, canvasElement);
             let ctx = document.getElementById('myWidget' + itemId).getContext('2d');
+
+            // get display options for the item
             let chartOptions = OCA.Analytics.UI.getDefaultChartOptions();
             let pageId = itemId.split('-')[0];
             let itemIndex = itemId.split('-')[1];
             let itemContent = OCA.Analytics.Panorama.currentPanorama.pages[pageId].reports[itemIndex];
+
+            // legend = true
             if (itemContent?.options?.legend !== undefined) {
                 chartOptions.plugins.legend.display = itemContent.options.legend;
             }
+
             OCA.Analytics.Visualization.buildChart(ctx, jsondata, chartOptions);
         } else {
             let canvasElement = document.getElementById(`myWidget${itemId}`);
@@ -480,12 +485,41 @@ OCA.Analytics.Panorama = {
         overlayText.id = 'overlayText';
         overlay.appendChild(overlayText);
 
-        // add item specific options to overlay
+        // add item specific extra options to overlay
+        OCA.Analytics.Panorama.addDisplayOptionsToOverlay(overlay, flexItem);
+
+        flexItem.appendChild(overlay);
+
+        overlay.addEventListener('click', function (evt) {
+            // Remove the active state from any previous flex-item
+            OCA.Analytics.Panorama.resetEditOverlays();
+
+            // indicate now active overlay
+            evt.currentTarget.classList.add('active');
+            evt.currentTarget.firstChild.innerText = t('analytics', 'choose the content');
+
+            OCA.Analytics.Panorama.showWidgetContentSelector(evt.currentTarget.dataset.itemId); // Position the menu items in a circle
+        });
+
+        if (isActive) {
+            // when the item was drawn after a report change, the overlay needs to be added again
+            //overlay.classList.add('active');
+            //overlay.firstChild.innerText = '';
+        }
+    },
+
+    /**
+     * Adds display options to the overlay depending on the item type.
+     * Extend this function to support more types/options in the future.
+     */
+    addDisplayOptionsToOverlay: function(overlay, flexItem) {
         let itemId = flexItem.id;
         let pageId = itemId.split('-')[0];
         let itemIndex = itemId.split('-')[1];
         let page = OCA.Analytics.Panorama.currentPanorama.pages[pageId];
         let itemContent = page.reports[itemIndex];
+
+        // legend true/false for reports
         if (itemContent && parseInt(itemContent.type) === OCA.Analytics.Panorama.TYPE_REPORT) {
             let optionsContainer = document.createElement('div');
             optionsContainer.classList.add('overlayOptions');
@@ -518,24 +552,6 @@ OCA.Analytics.Panorama = {
             optionsContainer.appendChild(legendCheckbox);
             optionsContainer.appendChild(legendLabel);
             overlay.appendChild(optionsContainer);
-        }
-        flexItem.appendChild(overlay);
-
-        overlay.addEventListener('click', function (evt) {
-            // Remove the active state from any previous flex-item
-            OCA.Analytics.Panorama.resetEditOverlays();
-
-            // indicate now active overlay
-            evt.currentTarget.classList.add('active');
-            evt.currentTarget.firstChild.innerText = t('analytics', 'choose the content');
-
-            OCA.Analytics.Panorama.showWidgetContentSelector(evt.currentTarget.dataset.itemId); // Position the menu items in a circle
-        });
-
-        if (isActive) {
-            // when the item was drawn after a report change, the overlay needs to be added again
-            //overlay.classList.add('active');
-            //overlay.firstChild.innerText = '';
         }
     },
 

--- a/lib/Service/PanoramaService.php
+++ b/lib/Service/PanoramaService.php
@@ -63,6 +63,12 @@ class PanoramaService {
 	 */
 	public function index(): array {
 		$ownPanorama = $this->PanoramaMapper->index();
+		// Set permissions for all own panoramas
+		foreach ($ownPanorama as &$panorama) {
+			$panorama['permissions'] = \OCP\Constants::PERMISSION_UPDATE;
+		}
+		unset($panorama);
+
 		$sharedPanoramas = $this->ShareService->getSharedItems(ShareService::SHARE_ITEM_TYPE_PANORAMA);
 		$keysToKeep = array('id', 'name', 'dataset', 'favorite', 'parent', 'type', 'pages', 'isShare', 'shareId', 'permissions');
 

--- a/templates/part.content_panorama.php
+++ b/templates/part.content_panorama.php
@@ -270,17 +270,21 @@
 
     .overlayText {
         background-color: white;
-        padding: 5px; /* Adjust padding as needed */
+        padding: 10px;
         cursor: pointer;
+        border-radius: 5px;
     }
 
     .overlayOptions {
+        border-radius: 10px;
         position: absolute;
-        left: 5px;
-        bottom: 5px;
+        bottom: 10px;
         background-color: rgba(255,255,255,0.8);
         font-size: 12px;
         padding: 2px 4px;
+        display: flex;
+        align-items: center;
+        gap: 4px; /* Optional: adds space between checkbox and label */
     }
 
     #reportSelectorContainer {

--- a/templates/part.content_panorama.php
+++ b/templates/part.content_panorama.php
@@ -274,6 +274,15 @@
         cursor: pointer;
     }
 
+    .overlayOptions {
+        position: absolute;
+        left: 5px;
+        bottom: 5px;
+        background-color: rgba(255,255,255,0.8);
+        font-size: 12px;
+        padding: 2px 4px;
+    }
+
     #reportSelectorContainer {
         max-height: 280px; /* Adjust the max height as needed */
         overflow-y: auto; /* Enables vertical scrolling when content overflows */


### PR DESCRIPTION
## Summary
- allow hiding the legend for panorama widgets
- persist legend option in page settings
- respect legend option when rendering charts
- style overlay options box

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844126524408333bd15d5a84475cdf8