### PR TITLE
Add timeSeries data model for e.g. Health data

### DIFF
--- a/js/filter.js
+++ b/js/filter.js
@@ -777,6 +777,8 @@ OCA.Analytics.Filter = {
             dataModel = OCA.Analytics.currentReportData.options.chartoptions["analyticsModel"];
             if (dataModel === 'accountModel') {
                 container.getElementById('analyticsModelOpt2').checked = true;
+            } else if (dataModel === 'timeSeriesModel') {
+                container.getElementById('analyticsModelOpt3').checked = true;
             }
         } catch (e) {
             dataModel = '';
@@ -853,7 +855,7 @@ OCA.Analytics.Filter = {
         let chartOptionsObj = (chartOptions && chartOptions.length !== 0) ? chartOptions : {};
 
         let dataModel = document.querySelector('input[name="analyticsModel"]:checked').value;
-        if (dataModel === 'accountModel') {
+        if (dataModel === 'accountModel' || dataModel === 'timeSeriesModel') {
             let enableModel = {analyticsModel: dataModel};
             try {
                 // if there are existing settings, merge them

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -785,6 +785,7 @@ OCA.Analytics.Visualization = {
         let dataModel = '';
         let header = data.header.slice(1);
         const isTopGrouping = !!data.options?.filteroptions?.topN;
+        let datasetCounter = 0;
 
         if (data.options.chartoptions !== null) {
             if (data.options.chartoptions?.analyticsModel !== undefined) {
@@ -807,10 +808,24 @@ OCA.Analytics.Visualization = {
                 }));
                 datasets.push({label: label, data: dataPoints, yAxisID: 'primary'});
             });
+        } else if (dataModel === 'timeSeriesModel') {
+            xAxisCategories = data.map(row => row[0]);
+            header.forEach((seriesName, index) => {
+                const dataset = {
+                    label: seriesName,
+                    data: [],
+                    hidden: datasetCounter >= 4 && !isTopGrouping,
+                    yAxisID: 'primary'
+                };
+                data.forEach(row => {
+                    dataset.data.push({x: row[0], y: parseFloat(row[index + 1])});
+                });
+                datasets.push(dataset);
+                datasetCounter++;
+            });
         } else {
             // KPI-Model: Use existing logic
             const labelMap = new Map();
-            let datasetCounter = 0;
             data.forEach((row) => {
                 let dataSeriesColumn, characteristicColumn, value;
                 if (row.length >= 3) {

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -872,6 +872,11 @@
                 <label for="opt2"> <?php p($l->t('In columns')); ?></label><br>
                 <span class="userGuidance"><?php p($l->t('One line per topic with the values in the columns')); ?></span>
             </div>
+            <div style="display: table-cell; width: 200px; text-align: center;">
+                <input type="radio" id="analyticsModelOpt3" name="analyticsModel" value="timeSeriesModel"/><br>
+                <label for="opt3"> <?php p($l->t('Timestamps in first column')); ?></label><br>
+                <span class="userGuidance"><?php p($l->t('One line per timestamp with the series in the columns')); ?></span>
+            </div>
         </div>
     </div>
     <br>


### PR DESCRIPTION
## Summary
- handle `timeSeriesModel` input where timestamps are in the first column
- allow selecting the new model from filter options
- support conversion in dashboard and visualization code

## Testing
- `phpunit -c phpunit.xml --dont-report-useless-tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454be2000083338fccda1be3c38205