### PR TITLE
Add active option indicators in report menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1056,3 +1056,17 @@ div.dt-container .dt-paging .dt-paging-button {
     font-size: 3.5rem;
     font-weight: 400;
 }
+/* indicator for report options when filters are active */
+.report-option-active span:first-child {
+    position: relative;
+}
+.report-option-active span:first-child::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 6px;
+    height: 6px;
+    background-color: var(--color-primary);
+    border-radius: 50%;
+}

--- a/js/filter.js
+++ b/js/filter.js
@@ -27,6 +27,36 @@ OCA.Analytics.Filter = {
     },
 
     /**
+     * Update indicator state of report menu options
+     */
+    updateReportMenuIndicators: function () {
+        const filterOptions = OCA.Analytics.currentReportData.options.filteroptions || {};
+        const map = {
+            drilldown: 'reportMenuColumnSelection',
+            sort: 'reportMenuSort',
+            topN: 'reportMenuTopN',
+            timeAggregation: 'reportMenuTimeAggregation'
+        };
+        for (const [key, id] of Object.entries(map)) {
+            const el = document.getElementById(id);
+            if (!el) {
+                continue;
+            }
+            let active;
+            if (key === 'drilldown') {
+                active = !!(filterOptions.drilldown && Object.keys(filterOptions.drilldown).length);
+            } else {
+                active = filterOptions[key] !== undefined;
+            }
+            if (active) {
+                el.classList.add('report-option-active');
+            } else {
+                el.classList.remove('report-option-active');
+            }
+        }
+    },
+
+    /**
      * Display the drilldown configuration dialog allowing the user
      * to enable or disable individual dimensions for aggregation.
      */
@@ -446,6 +476,9 @@ OCA.Analytics.Filter = {
         } else {
             saveIcon.style.display = "none";
         }
+
+        // update report menu indicators for active options
+        OCA.Analytics.Filter.updateReportMenuIndicators();
     },
 
     /**


### PR DESCRIPTION
## Summary
- add CSS class for active report menu indicators
- implement `updateReportMenuIndicators` to toggle the class based on filter options
- refresh indicators when filter visualisation is updated

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68455697c8cc8333a8d8e82038bbccc6