### PR TITLE
Remove REST API modal

### DIFF
--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -802,7 +802,7 @@ OCA.Analytics.Sidebar.Data = {
                     document.getElementById('DataTextDimension2').innerText = data['dimension2'];
                     document.getElementById('DataTextValue').innerText = data['value'];
                     document.getElementById('DataApiDataset').innerText = data['dataset'];
-                    const apiUrl = OC.generateUrl('/apps/analytics/api/3.0/data/') + data['dataset'] + '/add';
+                    const apiUrl = OC.generateUrl('/apps/analytics/api/4.0/data/') + data['dataset'] + '/add';
                     document.getElementById('apiLinkText').innerText = apiUrl;
                     document.getElementById('apiLink').dataset.link = OC.getProtocol() + '://' + OC.getHostName() + (OC.getPort() !== '' ? ':' + OC.getPort() : '') + apiUrl;
                     //document.getElementById('DataTextvalue').addEventListener('keydown', OCA.Analytics.Sidebar.Data.handleDataInputEnter);

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -804,7 +804,7 @@ OCA.Analytics.Sidebar.Data = {
                     document.getElementById('DataApiDataset').innerText = data['dataset'];
                     const apiUrl = OC.generateUrl('/apps/analytics/api/3.0/data/') + data['dataset'] + '/add';
                     document.getElementById('apiLinkText').innerText = apiUrl;
-                    document.getElementById('apiLinkClipboard').value = OC.getProtocol() + '://' + OC.getHostName() + (OC.getPort() !== '' ? ':' + OC.getPort() : '') + apiUrl;
+                    document.getElementById('apiLink').dataset.link = OC.getProtocol() + '://' + OC.getHostName() + (OC.getPort() !== '' ? ':' + OC.getPort() : '') + apiUrl;
                     //document.getElementById('DataTextvalue').addEventListener('keydown', OCA.Analytics.Sidebar.Data.handleDataInputEnter);
                     document.getElementById('updateDataButton').addEventListener('click', OCA.Analytics.Sidebar.Data.handleDataUpdateButton);
                     document.getElementById('deleteDataButton').addEventListener('click', OCA.Analytics.Sidebar.Data.handleDataDeletionButton);
@@ -864,7 +864,7 @@ OCA.Analytics.Sidebar.Data = {
     },
 
     handleDataApiButton: function (evt) {
-        let link = evt.target.nextElementSibling.value;
+        let link = evt.target.dataset.link;
         evt.target.classList.replace('icon-clippy', 'icon-checkmark-color');
         let textArea = document.createElement('textArea');
         textArea.value = link;

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -802,6 +802,9 @@ OCA.Analytics.Sidebar.Data = {
                     document.getElementById('DataTextDimension2').innerText = data['dimension2'];
                     document.getElementById('DataTextValue').innerText = data['value'];
                     document.getElementById('DataApiDataset').innerText = data['dataset'];
+                    const apiUrl = OC.generateUrl('/apps/analytics/api/3.0/data/') + data['dataset'] + '/add';
+                    document.getElementById('apiLinkText').innerText = apiUrl;
+                    document.getElementById('apiLinkClipboard').value = OC.getProtocol() + '://' + OC.getHostName() + (OC.getPort() !== '' ? ':' + OC.getPort() : '') + apiUrl;
                     //document.getElementById('DataTextvalue').addEventListener('keydown', OCA.Analytics.Sidebar.Data.handleDataInputEnter);
                     document.getElementById('updateDataButton').addEventListener('click', OCA.Analytics.Sidebar.Data.handleDataUpdateButton);
                     document.getElementById('deleteDataButton').addEventListener('click', OCA.Analytics.Sidebar.Data.handleDataDeletionButton);
@@ -860,16 +863,16 @@ OCA.Analytics.Sidebar.Data = {
         document.getElementById('importDataClipboardButtonGo').addEventListener('click', OCA.Analytics.Sidebar.Backend.importCsvData);
     },
 
-    handleDataApiButton: function () {
-        let header = t('analytics', 'REST API parameters');
-        let text = OC.generateUrl('/apps/analytics/api/3.0/data/')
-            + document.getElementById('DataApiDataset').innerText
-            + '/add<br><br>'
-            + '<a href="https://github.com/rello/analytics/wiki/API" target="_blank">'
-            + t('analytics', 'More Information …')
-            + '</a>';
-        let guidance = t('analytics', 'Use this endpoint to submit data via an API:');
-        OCA.Analytics.Notification.info(header, text, guidance);
+    handleDataApiButton: function (evt) {
+        let link = evt.target.nextElementSibling.value;
+        evt.target.classList.replace('icon-clippy', 'icon-checkmark-color');
+        let textArea = document.createElement('textArea');
+        textArea.value = link;
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+        OCA.Analytics.Notification.notification('success', t('analytics', 'Link copied'));
     },
 
     handleDataAdvancedButton: function () {

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -433,7 +433,17 @@
     <div class="sidebarHeaderClosed"><h3 id="dataApiSectionHeaderH3"
                                          class="sidebarPointer"><?php p($l->t('REST API')); ?></h3></div>
     <div id="dataApiSection" style="display: none; width: 100%; max-width: 500px;">
-        <div id="apiLink" class="clipboard-button icon icon-clippy" style="width: 20px;"></div>
+        <div class="userGuidance"><?php p($l->t('Use this endpoint to submit data via an API:')); ?></div>
+        <div class="table" style="display: table; width: 100%;">
+            <div style="display: table-row;">
+                <span id="apiLinkText" style="display: table-cell; word-break: break-all;"></span>
+                <span style="display: table-cell; width: 20px;">
+                    <a id="apiLink" class="clipboard-button icon icon-clippy"></a>
+                    <textarea id="apiLinkClipboard" hidden></textarea>
+                </span>
+            </div>
+        </div>
+        <a class="userGuidance" href="https://github.com/Rello/analytics/wiki/API" target="_blank"><?php p($l->t('More Information …')); ?></a>
         <input type="hidden" id="DataApiDataset">
         <br>
     </div>

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -434,14 +434,9 @@
                                          class="sidebarPointer"><?php p($l->t('REST API')); ?></h3></div>
     <div id="dataApiSection" style="display: none; width: 100%; max-width: 500px;">
         <div class="userGuidance"><?php p($l->t('Use this endpoint to submit data via an API:')); ?></div>
-        <div class="table" style="display: table; width: 100%;">
-            <div style="display: table-row;">
-                <span id="apiLinkText" style="display: table-cell; word-break: break-all;"></span>
-                <span style="display: table-cell; width: 20px;">
-                    <a id="apiLink" class="clipboard-button icon icon-clippy"></a>
-                    <textarea id="apiLinkClipboard" hidden></textarea>
-                </span>
-            </div>
+        <div style="display: flex; align-items: center;">
+            <span id="apiLinkText" style="word-break: break-all;"></span>
+            <a id="apiLink" class="clipboard-button icon icon-clippy" style="margin-left: 5px;"></a>
         </div>
         <a class="userGuidance" href="https://github.com/Rello/analytics/wiki/API" target="_blank"><?php p($l->t('More Information …')); ?></a>
         <input type="hidden" id="DataApiDataset">

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -433,12 +433,15 @@
     <div class="sidebarHeaderClosed"><h3 id="dataApiSectionHeaderH3"
                                          class="sidebarPointer"><?php p($l->t('REST API')); ?></h3></div>
     <div id="dataApiSection" style="display: none; width: 100%; max-width: 500px;">
-        <div class="userGuidance"><?php p($l->t('Use this endpoint to submit data via an API:')); ?></div>
+        <div><?php p($l->t('Use this endpoint to submit data via an API:')); ?></div>
+        <br><br>
         <div style="display: flex; align-items: center;">
             <span id="apiLinkText" style="word-break: break-all;"></span>
             <a id="apiLink" class="clipboard-button icon icon-clippy" style="margin-left: 5px;"></a>
         </div>
-        <a class="userGuidance" href="https://github.com/Rello/analytics/wiki/API" target="_blank"><?php p($l->t('More Information …')); ?></a>
+        <br><br>
+        <a class="userGuidance" href="https://github.com/Rello/analytics/wiki/API"
+           target="_blank"><?php p($l->t('More Information …')); ?></a>
         <input type="hidden" id="DataApiDataset">
         <br>
     </div>
@@ -453,8 +456,8 @@
 
 <template id="templateThreshold">
     <div class="userGuidance"><?php p($l->t('Thresholds can trigger notifications and color coding in reports.')); ?>
-    <a class="userGuidance" href="https://github.com/Rello/analytics/wiki/Thresholds"
-       target="_blank"><?php p($l->t('More information …')); ?></a></div>
+        <a class="userGuidance" href="https://github.com/Rello/analytics/wiki/Thresholds"
+           target="_blank"><?php p($l->t('More information …')); ?></a></div>
     <br>
     <div class="table" style="display: table;">
         <div style="display: table-row;">
@@ -475,7 +478,7 @@
 					p($l->t('contains')); ?></option>
                 <option value="IN"><?php // TRANSLATORS description in a dropdown; limited space
 					p($l->t('list of values')); ?></option>
-             </select>
+            </select>
 
         </div>
         <div style="display: table-row;">
@@ -507,7 +510,7 @@
     </div>
     <br>
     <button id="sidebarThresholdCreateButton" type="button" class="primary" data-id="">
-                <?php p($l->t('Save threshold')); ?>
+		<?php p($l->t('Save threshold')); ?>
     </button>
     <button id="sidebarThresholdCreateNewButton" type="button" class="secondary">
 		<?php p($l->t('Notification for new records')); ?>
@@ -516,7 +519,7 @@
     <br>
     <br>
     <div class="userGuidance"><?php
-			p($l->t('Existing thresholds will be evaluated in the order shown below. The order can be changed by drag & drop.')); ?></div>
+		p($l->t('Existing thresholds will be evaluated in the order shown below. The order can be changed by drag & drop.')); ?></div>
     <br>
     <div id="sidebarThresholdList"></div>
 </template>


### PR DESCRIPTION
## Summary
- expose REST API information inside the Data sidebar section
- copy API link to clipboard instead of opening a modal

## Testing
- `phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684557449ab883338946e95982cd8373