### PR TITLE
Unify navigation lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Reload report after threshold modifications
 - Highlight selected threshold row in sidebar
 
+### Added
+- Unified navigation showing panoramas and reports together
+
 ## 5.6.1 - 2025-06-09
 ### Fixed
 - Threshold validation for numbers with thousands separator


### PR DESCRIPTION
## Summary
- fetch panoramas and reports at the same time
- handle navigation and deletion based on item type
- document unified navigation in changelog

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit --version` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6855d65f4dcc8333b7a7336ea892f737