### PR TITLE
Load panoramas in dashboard favorites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Overview moved into the navigation and highlights when no item is selected
 - Removed dataset maintenance mode; datasets are fetched with reports and panoramas
 - Only one navigation section can be open at a time
+- Dashboard favorites list now also shows panoramas
+- Favorites are fetched in parallel for improved load times
 
 ## 5.6.1 - 2025-06-09
 ### Fixed


### PR DESCRIPTION
## Summary
- show panorama favorites in the main dashboard
- fetch favorites from both sources in parallel
- update changelog

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eff67807083339bbdfb9b95f65e41