### PR TITLE
Fix favorites navigation rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Reload report after threshold modifications
 - Highlight selected threshold row in sidebar
 - Remove duplicate panorama handlers from navigation logic
+- Favorite items now remain in their original sections and update without reloading
 
 ### Added
 - Unified navigation showing panoramas and reports together


### PR DESCRIPTION
## Summary
- duplicate favorite items in their normal navigation sections
- update Favorites section immediately when toggling

## Testing
- `phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8ff1cd08833384800d1b84276dea