### PR TITLE
Ensure editing loads selected report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Highlight selected threshold row in sidebar
 - Remove duplicate panorama handlers from navigation logic
 - Favorite items now remain in their original sections and update without reloading
+- Load correct report when opening sidebar via navigation menu edit
 
 ### Added
 - Unified navigation showing panoramas and reports together

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -611,6 +611,15 @@ OCA.Analytics.Navigation = {
             document.querySelector('.app-navigation-entry-menu.open').classList.remove('open');
         }
         evt.stopPropagation();
+
+        const menu = evt.target.closest('#navigationMenu');
+        const id = menu.dataset.id;
+        const type = menu.dataset.item_type;
+        const anchor = document.querySelector(
+            '#navigationDatasets a[data-id="' + id + '"][data-item_type="' + type + '"]'
+        );
+        anchor?.click();
+
         OCA.Analytics.Sidebar?.showSidebar?.(evt);
     },
 

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -20,21 +20,15 @@ OCA.Analytics.Sidebar = {
         let datasetType = navigationItem.dataset.type;
         let appsidebar = document.getElementById('app-sidebar');
 
-        if (appsidebar.dataset.id === datasetId && !OCA.Analytics.isDataset) {
+        if (appsidebar.dataset.id === datasetId) {
             OCA.Analytics.Sidebar.close();
         } else {
             document.getElementById('sidebarTitle').innerText = navigationItem.dataset.name;
             OCA.Analytics.Sidebar.constructTabs(parseInt(datasetType));
 
-            if (!OCA.Analytics.isDataset) {
-                if (appsidebar.dataset.id === '') {
-                    document.getElementById('sidebarClose').addEventListener('click', OCA.Analytics.Sidebar.close);
-                    // OC.Apps not working anymore
-                    appsidebar.classList.remove('disappear');
-                }
-            } else {
-                OCA.Analytics.Visualization.hideElement('analytics-intro');
-                OCA.Analytics.Visualization.showElement('analytics-content');
+            if (appsidebar.dataset.id === '') {
+                document.getElementById('sidebarClose').addEventListener('click', OCA.Analytics.Sidebar.close);
+                // OC.Apps not working anymore
                 appsidebar.classList.remove('disappear');
             }
             appsidebar.dataset.id = datasetId;


### PR DESCRIPTION
## Summary
- load the selected report before opening edit sidebar
- simplify sidebar show logic for reports
- document fix in changelog

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9e374f3883339d55ab23ffca7eb2