### PR TITLE
Modernize input styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Modernized sidebar input styling with material-like underline
 - Sidebar inputs now override Nextcloud global form rules
+- Dropdown suggestion lists now have borders and background matching inputs
 
 ## 5.6.1 - 2025-06-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Modernized sidebar input styling with material-like underline
 - Sidebar inputs now override Nextcloud global form rules
 - Dropdown suggestion lists now have borders and background matching inputs
+- Select inputs use the same material underline styling
 
 ## 5.6.1 - 2025-06-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Debounce share search results and update list smoothly
 
 - Modernized sidebar input styling with material-like underline
+- Sidebar inputs now override Nextcloud global form rules
 
 ## 5.6.1 - 2025-06-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Favorites are fetched in parallel for improved load times
 - Debounce share search results and update list smoothly
 
+- Modernized sidebar input styling with material-like underline
+
 ## 5.6.1 - 2025-06-09
 ### Fixed
 - Threshold validation for numbers with thousands separator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Sidebar inputs now override Nextcloud global form rules
 - Dropdown suggestion lists now have borders and background matching inputs
 - Select inputs use the same material underline styling
+- Textarea fields now share the material underline style
 
 ## 5.6.1 - 2025-06-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,8 @@
 - Dashboard favorites list now also shows panoramas
 - Favorites are fetched in parallel for improved load times
 - Debounce share search results and update list smoothly
+- Material design for input field across the whole app
 
-- Modernized sidebar input styling with material-like underline
-- Sidebar inputs now override Nextcloud global form rules
-- Dropdown suggestion lists now have borders and background matching inputs
-- Select inputs use the same material underline styling
-- Textarea fields now share the material underline style
 
 ## 5.6.1 - 2025-06-09
 ### Fixed

--- a/css/style.css
+++ b/css/style.css
@@ -452,10 +452,13 @@ table.dataTable tbody tr {
 
 input.sidebarInput,
 select.sidebarInput,
+textarea.sidebarInput,
 input.menueInput,
 select.menueInput,
+textarea.menueInput,
 input.optionsInput,
 select.optionsInput,
+textarea.optionsInput,
 input.optionsInputValue {
     border: none !important;
     border-bottom: 1px solid var(--color-border-dark) !important;
@@ -469,10 +472,13 @@ input.optionsInputValue {
 
 input.sidebarInput:focus,
 select.sidebarInput:focus,
+textarea.sidebarInput:focus,
 input.menueInput:focus,
 select.menueInput:focus,
+textarea.menueInput:focus,
 input.optionsInput:focus,
 select.optionsInput:focus,
+textarea.optionsInput:focus,
 input.optionsInputValue:focus {
     outline: none;
     border-bottom: 2px solid var(--color-primary-element) !important;
@@ -486,10 +492,13 @@ input.optionsInputValue:focus {
 
 input.sidebarInput:hover,
 select.sidebarInput:hover,
+textarea.sidebarInput:hover,
 input.menueInput:hover,
 select.menueInput:hover,
+textarea.menueInput:hover,
 input.optionsInput:hover,
-select.optionsInput:hover {
+select.optionsInput:hover,
+textarea.optionsInput:hover {
     border-bottom-color: var(--color-primary-element) !important;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -444,8 +444,6 @@ table.dataTable tbody tr {
 
 .optionsInput {
     width: 130px;
-    border: 1px solid var(--color-border-dark) !important;
-    border-radius: var(--border-radius-large);
 }
 
 .sidebarInput, .menueInput, .optionsInputValue {
@@ -453,7 +451,11 @@ table.dataTable tbody tr {
 }
 
 input.sidebarInput,
+select.sidebarInput,
 input.menueInput,
+select.menueInput,
+input.optionsInput,
+select.optionsInput,
 input.optionsInputValue {
     border: none !important;
     border-bottom: 1px solid var(--color-border-dark) !important;
@@ -466,7 +468,11 @@ input.optionsInputValue {
 }
 
 input.sidebarInput:focus,
+select.sidebarInput:focus,
 input.menueInput:focus,
+select.menueInput:focus,
+input.optionsInput:focus,
+select.optionsInput:focus,
 input.optionsInputValue:focus {
     outline: none;
     border-bottom: 2px solid var(--color-primary-element) !important;
@@ -479,7 +485,11 @@ input.optionsInputValue:focus {
 }
 
 input.sidebarInput:hover,
-input.menueInput:hover {
+select.sidebarInput:hover,
+input.menueInput:hover,
+select.menueInput:hover,
+input.optionsInput:hover,
+select.optionsInput:hover {
     border-bottom-color: var(--color-primary-element) !important;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -925,14 +925,14 @@ div.dt-container .dt-paging .dt-paging-button {
 }
 
 .dropDownList {
-    border-color: var(--color-primary-element) !important;
-    /* position: absolute; hide so the full menu is being shown */
-    z-index: 9999;
-    background-color: var(--color-main-background);
+    list-style: none;
+    margin: -3px 0 0;
+    padding: 0;
+    border: 1px solid var(--color-border-dark) !important;
     border-top: none !important;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-    margin-top: -3px;
+    border-radius: 0 0 var(--border-radius-large) var(--border-radius-large);
+    background-color: var(--color-main-background);
+    z-index: 9999;
 }
 
 .dropDownList > li {
@@ -949,10 +949,7 @@ div.dt-container .dt-paging .dt-paging-button {
 }
 
 .dropDownListParentOpen {
-    border-color: var(--color-primary-element) !important;
     border-bottom: none !important;
-    border-bottom-left-radius: 0 !important;
-    border-bottom-right-radius: 0 !important;
 }
 
 .dragAndDropPlaceholder {

--- a/css/style.css
+++ b/css/style.css
@@ -450,8 +450,17 @@ table.dataTable tbody tr {
 
 .sidebarInput, .menueInput, .optionsInputValue {
     width: 200px;
-    border: 1px solid var(--color-border-dark) !important;
-    border-radius: var(--border-radius-large);
+    border: none;
+    border-bottom: 1px solid var(--color-border-dark);
+    border-radius: 0;
+    background-color: transparent;
+    padding: 4px 0;
+    transition: border-color .2s;
+}
+
+.sidebarInput:focus, .menueInput:focus, .optionsInputValue:focus {
+    outline: none;
+    border-bottom: 2px solid var(--color-primary-element);
 }
 
 .dt-input {
@@ -460,7 +469,11 @@ table.dataTable tbody tr {
     border-radius: var(--border-radius-large);
 }
 
-.sidebarInput:hover, .menueInput:hover, .dt-input:hover {
+.sidebarInput:hover, .menueInput:hover {
+    border-bottom-color: var(--color-primary-element) !important;
+}
+
+.dt-input:hover {
     border-color: var(--color-primary-element) !important;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -450,17 +450,26 @@ table.dataTable tbody tr {
 
 .sidebarInput, .menueInput, .optionsInputValue {
     width: 200px;
-    border: none;
-    border-bottom: 1px solid var(--color-border-dark);
+}
+
+input.sidebarInput,
+input.menueInput,
+input.optionsInputValue {
+    border: none !important;
+    border-bottom: 1px solid var(--color-border-dark) !important;
     border-radius: 0;
     background-color: transparent;
     padding: 4px 0;
     transition: border-color .2s;
+    appearance: none;
+    box-shadow: none;
 }
 
-.sidebarInput:focus, .menueInput:focus, .optionsInputValue:focus {
+input.sidebarInput:focus,
+input.menueInput:focus,
+input.optionsInputValue:focus {
     outline: none;
-    border-bottom: 2px solid var(--color-primary-element);
+    border-bottom: 2px solid var(--color-primary-element) !important;
 }
 
 .dt-input {
@@ -469,7 +478,8 @@ table.dataTable tbody tr {
     border-radius: var(--border-radius-large);
 }
 
-.sidebarInput:hover, .menueInput:hover {
+input.sidebarInput:hover,
+input.menueInput:hover {
     border-bottom-color: var(--color-primary-element) !important;
 }
 


### PR DESCRIPTION
## Summary
- restyle `sidebarInput` fields for a cleaner material-like look
- note the style change in the changelog

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653ecf221c833380c4f4e7a0c975ba