### PR TITLE
Improve dataset maintenance navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Primary action button moved to the right side of dialog
 - Introduced custom analyticsPrimary button style and updated dialog buttons
 - Sidebar action buttons and tabs now use analyticsPrimary styling
+- Dataset maintenance from the navigation now opens the dataset in place
 
 ## 5.6.2 - 2025-06-10
 ### Fixed

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -630,11 +630,30 @@ OCA.Analytics.Navigation = {
 
 
     handleAdvancedClicked: function (evt) {
-        let datasetId = evt.target.parentNode.dataset.dataset;
-        let datasetUrl = '';
-        if (datasetId !== undefined) datasetUrl = '/' + datasetId
-        window.location = OC.generateUrl('apps/analytics/d') + datasetUrl;
+        if (document.querySelector('.app-navigation-entry-menu.open') !== null) {
+            document.querySelector('.app-navigation-entry-menu.open').classList.remove('open');
+        }
         evt.stopPropagation();
+
+        const datasetId = evt.target.closest('a').dataset.dataset;
+        const anchor = document.querySelector(
+            '#navigationDatasets a[data-id="' + datasetId + '"][data-item_type="dataset"]'
+        );
+
+        if (anchor) {
+            let parent = anchor.parentElement;
+            while (parent && parent.id !== 'navigationDatasets') {
+                if (parent.classList && parent.classList.contains('collapsible')) {
+                    parent.classList.add('open');
+                }
+                parent = parent.parentElement;
+            }
+            anchor.click();
+            OCA.Analytics.Navigation.saveOpenState();
+        } else if (datasetId !== undefined) {
+            const datasetUrl = '/' + datasetId;
+            window.location = OC.generateUrl('apps/analytics/d') + datasetUrl;
+        }
     },
 
     handleFavoriteClicked: function (evt) {


### PR DESCRIPTION
## Summary
- keep folders open when selecting dataset maintenance from nav menu
- open dataset sidebar without page reload

## Testing
- `vendor/bin/phpunit -c phpunit.xml` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68690be7f9fc8333800de1a7824aa3a7