### PR TITLE
Fix navigation open state behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Primary action button moved to the right side of dialog
 - Introduced custom analyticsPrimary button style and updated dialog buttons
 - Sidebar action buttons and tabs now use analyticsPrimary styling
+- Navigation keeps Favorites open and only one other section expands at a time
 
 ## 5.6.2 - 2025-06-10
 ### Fixed

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -121,7 +121,7 @@ OCA.Analytics.Navigation = {
         if (data === undefined || data.length === 0) {
             nav.appendChild(OCA.Analytics.Navigation.buildIntroRow());
         } else {
-            nav.appendChild(OCA.Analytics.Navigation.buildSection(t('analytics', 'Favorites'), 'section-favorites', 'icon-analytics-star', true));
+            nav.appendChild(OCA.Analytics.Navigation.buildSection(t('analytics', 'Favorites'), 'section-favorites', 'icon-analytics-star', true, false));
             nav.appendChild(OCA.Analytics.Navigation.buildSection(t('analytics', 'Panoramas'), 'section-panoramas', 'icon-analytics-panorama'));
             nav.appendChild(OCA.Analytics.Navigation.buildSection(t('analytics', 'Reports'), 'section-reports', 'icon-analytics-report'));
             nav.appendChild(OCA.Analytics.Navigation.buildSection(t('analytics', 'Datasets'), 'section-datasets', 'icon-analytics-dataset'));
@@ -235,7 +235,7 @@ OCA.Analytics.Navigation = {
         return li;
     },
 
-    buildSection: function (title, id, icon = 'icon-folder', open = false) {
+    buildSection: function (title, id, icon = 'icon-folder', open = false, closable = true) {
         let li = document.createElement('li');
         li.classList.add('collapsible');
         if (open) {
@@ -248,7 +248,9 @@ OCA.Analytics.Navigation = {
         a.classList.add(icon, 'svg');
         a.innerText = title;
         a.setAttribute('href', '#');
-        a.addEventListener('click', OCA.Analytics.Navigation.handleGroupClicked);
+        if (closable) {
+            a.addEventListener('click', OCA.Analytics.Navigation.handleGroupClicked);
+        }
         div.appendChild(a);
         li.appendChild(div);
         let ul = document.createElement('ul');
@@ -678,9 +680,22 @@ OCA.Analytics.Navigation = {
 
     handleGroupClicked: function (evt) {
         const li = evt.target.parentNode.parentNode;
+        if (li.dataset.sectionId === 'section-favorites') {
+            // favorites are always open and not collapsible
+            evt.preventDefault();
+            return;
+        }
+
         if (li.classList.contains('open')) {
             li.classList.remove('open');
         } else {
+            // close other root sections except favorites
+            document.querySelectorAll('#navigationDatasets > li.collapsible[data-section-id]')
+                .forEach(node => {
+                    if (node !== li && node.dataset.sectionId !== 'section-favorites') {
+                        node.classList.remove('open');
+                    }
+                });
             li.classList.add('open');
         }
         OCA.Analytics.Navigation.saveOpenState();
@@ -765,6 +780,16 @@ OCA.Analytics.Navigation = {
                 if (li) li.classList.add('open');
             }
         });
+
+        const fav = document.querySelector('#navigationDatasets li.collapsible[data-section-id="section-favorites"]');
+        if (fav) fav.classList.add('open');
+
+        const openSections = Array.from(document.querySelectorAll('#navigationDatasets > li.collapsible[data-section-id]:not([data-section-id="section-favorites"]).open'));
+        if (openSections.length > 1) {
+            for (let i = 1; i < openSections.length; i++) {
+                openSections[i].classList.remove('open');
+            }
+        }
     },
 
     // TOdo: can be deleted


### PR DESCRIPTION
## Summary
- keep Favorites section permanently open
- allow only one other navigation section open at a time
- update CHANGELOG

## Testing
- `npm test` *(fails: Missing script, network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68690c45c04c83338ecb8f882df32cad