### PR TITLE
Enhance new item creation menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Primary action button moved to the right side of dialog
 - Introduced custom analyticsPrimary button style and updated dialog buttons
 - Sidebar action buttons and tabs now use analyticsPrimary styling
+- "New report" button renamed to a generic "New" selector with type options
 
 ## 5.6.2 - 2025-06-10
 ### Fixed

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -160,15 +160,32 @@ OCA.Analytics.Navigation = {
         a.classList.add('icon-add', 'svg');
         a.id = 'newReportButton';
         a.addEventListener('click', OCA.Analytics.Navigation.handleNewButton);
-        if (OCA.Analytics.isPanorama) {
-            // TRANSLATORS "Panorama" will be a product name. Do not translate, just capitalize if required
-            a.innerText = t('analytics', 'New panorama');
-        } else {
-            a.innerText = t('analytics', 'New report');
-        }
+        a.innerText = t('analytics', 'New');
+
         li.appendChild(navigationEntrydiv);
         navigationEntrydiv.appendChild(a);
+        navigationEntrydiv.appendChild(OCA.Analytics.Navigation.buildNewMenu());
         return li;
+    },
+
+    buildNewMenu: function () {
+        let menu = document.importNode(document.getElementById('templateNewMenu').content, true);
+        menu = menu.firstElementChild;
+
+        menu.querySelector('#newMenuReport').addEventListener('click', function (evt) {
+            evt.stopPropagation();
+            OCA.Analytics.Navigation.handleNewMenu('report');
+        });
+        menu.querySelector('#newMenuPanorama').addEventListener('click', function (evt) {
+            evt.stopPropagation();
+            OCA.Analytics.Navigation.handleNewMenu('panorama');
+        });
+        menu.querySelector('#newMenuDataset').addEventListener('click', function (evt) {
+            evt.stopPropagation();
+            OCA.Analytics.Navigation.handleNewMenu('dataset');
+        });
+
+        return menu;
     },
 
 
@@ -536,18 +553,24 @@ OCA.Analytics.Navigation = {
         return navigationMenu;
     },
 
-    handleNewButton: function () {
-        // ToDo: change app.js to register handler
+    handleNewButton: function (evt) {
+        evt?.preventDefault();
+        const openMenu = document.querySelector('.app-navigation-entry-menu.open');
+        if (openMenu && openMenu.id !== 'newMenu') {
+            openMenu.classList.remove('open');
+        }
 
-        let handler = OCA.Analytics.Navigation.handlers['create'];
+        const menu = document.getElementById('newMenu');
+        menu.classList.toggle('open');
+    },
+
+    handleNewMenu: function (type) {
+        const menu = document.getElementById('newMenu');
+        menu.classList.remove('open');
+
+        const handler = OCA.Analytics.Navigation.handlers['create']?.[type];
         if (handler) {
             handler();
-        } else if (OCA.Analytics.isDataset) {
-            OCA.Analytics.Wizard.sildeArray = [
-                ['', ''],
-                ['wizardDatasetGeneral', OCA.Analytics.Dataset.Dataset.wizard],
-            ];
-            OCA.Analytics.Wizard.show();
         }
     },
 

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -639,6 +639,16 @@
 
 </template>
 
+<template id="templateNewMenu">
+    <div id="newMenu" class="app-navigation-entry-menu">
+        <ul>
+            <li><a href="#" id="newMenuReport" data-type="report"><span class="icon-analytics-report"></span><span><?php p($l->t('Report')); ?></span></a></li>
+            <li><a href="#" id="newMenuPanorama" data-type="panorama"><span class="icon-analytics-panorama"></span><span><?php p($l->t('Panorama')); ?></span></a></li>
+            <li><a href="#" id="newMenuDataset" data-type="dataset"><span class="icon-analytics-dataset"></span><span><?php p($l->t('Dataset')); ?></span></a></li>
+        </ul>
+    </div>
+</template>
+
 <template id="templateNavigationMenu">
     <div id="navigationMenu" class="app-navigation-entry-menu">
         <ul>


### PR DESCRIPTION
## Summary
- rename the "New report" navigation entry to simply "New"
- add a dropdown template to choose report, panorama or dataset
- toggle this menu when clicking the New button and call the matching handler
- document the change in the changelog

## Testing
- `npm test` *(fails: Missing script and blocked network access)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690d5fb618833386d70e5bfbc1a954