### PR TITLE
Enhance new item creation menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Primary action button moved to the right side of dialog
 - Introduced custom analyticsPrimary button style and updated dialog buttons
 - Sidebar action buttons and tabs now use analyticsPrimary styling
+- "New report" button renamed to a generic "New" selector with type options
+### Fixed
+- Correctly create and delete items according to their selected type and show the dropdown above the New button
+- Navigation updates instantly when items are created or deleted without reloading
 
 ## 5.6.2 - 2025-06-10
 ### Fixed

--- a/css/style.css
+++ b/css/style.css
@@ -1335,3 +1335,7 @@ div[id^="analytics-content"] .button:not(.analyticsPrimary):hover,
         opacity: 1;
     }
 }
+#app-navigation #newMenu{
+    top:auto;
+    bottom:44px;
+}

--- a/js/dataset.js
+++ b/js/dataset.js
@@ -13,7 +13,11 @@
 document.addEventListener('DOMContentLoaded', function () {
     // register handlers for the navigation bar
     OCA.Analytics.Navigation.registerHandler('create', 'dataset', function () {
-        OCA.Analytics.Panorama.newPanorama();
+        OCA.Analytics.Wizard.sildeArray = [
+            ['', ''],
+            ['wizardDatasetGeneral', OCA.Analytics.Dataset.Dataset.wizard],
+        ];
+        OCA.Analytics.Wizard.show();
     });
 
     OCA.Analytics.Navigation.registerHandler('navigationClicked', 'dataset', function (event) {
@@ -21,7 +25,7 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     OCA.Analytics.Navigation.registerHandler('delete', 'dataset', function (event) {
-        OCA.Analytics.Panorama.handleDeletePanoramaButton(event);
+        OCA.Analytics.Dataset.Dataset.handleDeleteButton(event);
     });
 
     OCA.Analytics.Navigation.registerHandler('favoriteUpdate', 'dataset', function (id, isFavorite) {
@@ -676,15 +680,22 @@ Object.assign(OCA.Analytics.Dataset.Dataset = {
             })
         })
             .then(response => response.json())
+            .then(id => {
+                return fetch(OC.generateUrl('apps/analytics/dataset/') + id, {
+                    method: 'GET',
+                    headers: OCA.Analytics.headers(),
+                });
+            })
+            .then(response => response.json())
             .then(data => {
                 OCA.Analytics.Wizard.close();
-                OCA.Analytics.Navigation.init();
+                OCA.Analytics.Navigation.addNavigationItem(data);
+                const anchor = document.querySelector('#navigationDatasets a[data-id="' + data.id + '"][data-item_type="dataset"]');
+                anchor?.click();
             });
     },
 
     delete: function (reportId) {
-        document.getElementById('navigationDatasets').innerHTML = '<div style="text-align:center; padding-top:100px" class="get-metadata icon-loading"></div>';
-
         let requestUrl = OC.generateUrl('apps/analytics/dataset/') + reportId;
         fetch(requestUrl, {
             method: 'DELETE',
@@ -692,7 +703,8 @@ Object.assign(OCA.Analytics.Dataset.Dataset = {
         })
             .then(response => response.json())
             .then(data => {
-                OCA.Analytics.Navigation.init();
+                OCA.Analytics.Navigation.removeNavigationItem(reportId, 'dataset');
+                OCA.Analytics.Navigation.handleOverviewButton();
             });
     },
 

--- a/js/panorama.js
+++ b/js/panorama.js
@@ -1331,8 +1331,17 @@ Object.assign(OCA.Analytics.Panorama.Backend = {
             })
         })
             .then(response => response.json())
+            .then(id => {
+                return fetch(OC.generateUrl('apps/analytics/panorama/') + id, {
+                    method: 'GET',
+                    headers: OCA.Analytics.headers(),
+                });
+            })
+            .then(response => response.json())
             .then(data => {
-                OCA.Analytics.Navigation.init(data);
+                OCA.Analytics.Navigation.addNavigationItem(data);
+                const anchor = document.querySelector('#navigationDatasets a[data-id="' + data.id + '"][data-item_type="panorama"]');
+                anchor?.click();
             });
     },
 
@@ -1358,7 +1367,8 @@ Object.assign(OCA.Analytics.Panorama.Backend = {
         })
             .then(response => response.json())
             .then(data => {
-                OCA.Analytics.Navigation.init();
+                OCA.Analytics.Navigation.removeNavigationItem(id, 'panorama');
+                OCA.Analytics.Navigation.handleOverviewButton();
             })
             .catch(error => {
                 OCA.Analytics.Notification.notification('error', t('analytics', 'Request could not be processed'))

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -673,8 +673,7 @@ OCA.Analytics.Sidebar.Report = {
                         true
                     );
                 }
-                document.getElementById('navigationDatasets').innerHTML = '<div style="text-align:center; padding-top:100px" class="get-metadata icon-loading"></div>';
-                OCA.Analytics.Navigation.init();
+                OCA.Analytics.Navigation.removeNavigationItem(reportId, 'report');
                 OCA.Analytics.Navigation.handleOverviewButton();
             })
             .catch(error => {

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -639,6 +639,16 @@
 
 </template>
 
+<template id="templateNewMenu">
+    <div id="newMenu" class="app-navigation-entry-menu">
+        <ul>
+            <li><a href="#" id="newMenuReport" data-type="report"><span class="icon-analytics-report"></span><span><?php p($l->t('Report')); ?></span></a></li>
+            <li><a href="#" id="newMenuPanorama" data-type="panorama"><span class="icon-analytics-panorama"></span><span><?php p($l->t('Panorama')); ?></span></a></li>
+            <li><a href="#" id="newMenuDataset" data-type="dataset"><span class="icon-analytics-dataset"></span><span><?php p($l->t('Dataset')); ?></span></a></li>
+        </ul>
+    </div>
+</template>
+
 <template id="templateNavigationMenu">
     <div id="navigationMenu" class="app-navigation-entry-menu">
         <ul>


### PR DESCRIPTION
## Summary
- rename the "New report" navigation entry to simply "New"
- add a dropdown template to choose report, panorama or dataset
- toggle this menu when clicking the New button and call the matching handler
- document the change in the changelog
- make dropdown appear above the New button and use correct create/delete handlers for each type
- update navigation instantly when items are created or deleted without reloading

## Testing
- `npm test` *(fails: Missing script and blocked network access)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690d5fb618833386d70e5bfbc1a954