### PR TITLE
Update panorama dashboard widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Introduced custom analyticsPrimary button style and updated dialog buttons
 - Sidebar action buttons and tabs now use analyticsPrimary styling
 - "New report" button renamed to a generic "New" selector with type options
+- Panorama widgets on the dashboard now show an icon instead of a chart preview
 ### Fixed
 - Correctly create and delete items according to their selected type and show the dropdown above the New button
 - Navigation updates instantly when items are created or deleted without reloading

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -93,9 +93,11 @@ OCA.Analytics.Dashboard = {
 
                     for (let panorama of panoramaFavorites) {
                         let story = OCA.Analytics.stories.find(x => parseInt(x.id) === parseInt(panorama));
-                        let li = '<li id="analyticsWidgetItem' + panorama + '" class="analyticsWidgetItem" style="height: 50px;text-align: center;">';
-                        li += '<a href="' + OC.generateUrl('apps/analytics/pa/' + parseInt(panorama)) + '">' + story.name + '</a></li>';
+                        let li = '<li id="analyticsWidgetItem' + panorama + '" class="analyticsWidgetItem"></li>';
                         document.getElementById('ulAnalytics').insertAdjacentHTML('beforeend', li);
+                        let widgetRow = OCA.Analytics.Dashboard.buildPanoramaRow(story.name, panorama);
+                        document.getElementById('analyticsWidgetItem' + panorama).insertAdjacentHTML('beforeend', widgetRow);
+                        document.getElementById('analyticsWidgetItem' + panorama).addEventListener('click', OCA.Analytics.Dashboard.handleNavigationClicked);
                     }
                 } else {
                     document.getElementById('ulAnalytics').innerHTML = '<div>'
@@ -212,6 +214,19 @@ OCA.Analytics.Dashboard = {
                    <div id="chartContainer${reportId}">
                         <canvas id="myChart${reportId}" class="chartContainer"></canvas>
                     </div>
+                </div>
+            </a>`;
+    },
+
+    buildPanoramaRow: function (name, panoramaId) {
+        let href = OC.generateUrl('apps/analytics/pa/' + panoramaId);
+
+        return `<a href="${href}">
+                <div class="analyticsWidgetContent1">
+                    <div class="analyticsWidgetReport">${name}</div>
+                </div>
+                <div class="analyticsWidgetContent2">
+                    <span class="analyticsWidgetIcon icon-analytics-panorama"></span>
                 </div>
             </a>`;
     },

--- a/js/panorama.js
+++ b/js/panorama.js
@@ -1437,9 +1437,11 @@ Object.assign(OCA.Analytics.Panorama.Dashboard = {
                     for (let panorama of JSON.parse(xhr.response)) {
                         let story = OCA.Analytics.stories.find(x => parseInt(x.id) === parseInt(panorama));
 
-                        let li = '<li id="analyticsWidgetItem' + panorama + '" class="analyticsWidgetItem" style="height: 50px;text-align: center;">';
-                        li += '<a href="' + OC.generateUrl('apps/analytics/pa/' + parseInt(panorama)) + '">' + story.name + '</a></li>';
+                        let li = '<li id="analyticsWidgetItem' + panorama + '" class="analyticsWidgetItem"></li>';
                         document.getElementById('ulAnalytics').insertAdjacentHTML('beforeend', li);
+                        let widgetRow = OCA.Analytics.Dashboard.buildPanoramaRow(story.name, panorama);
+                        document.getElementById('analyticsWidgetItem' + panorama).insertAdjacentHTML('beforeend', widgetRow);
+                        document.getElementById('analyticsWidgetItem' + panorama).addEventListener('click', OCA.Analytics.Dashboard.handleNavigationClicked);
 
                     }
                 } else {


### PR DESCRIPTION
## Summary
- show panorama favorites in the dashboard using the same widget style as reports
- show the panorama icon instead of a chart preview

## Testing
- `phpunit -c phpunit.xml tests/Datasource` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5ea64b1c83339c832898b1abc4a9