### PR TITLE
Fix navigation for new items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Navigation keeps Favorites open and only one other section expands at a time
 - Dataset maintenance from the navigation now opens the dataset in place
 - Sidebar buttons across all tabs now align to the right
+- Newly created items open immediately and appear in the correct navigation section
 
 ## 5.6.2 - 2025-06-10
 ### Fixed

--- a/js/dataset.js
+++ b/js/dataset.js
@@ -689,6 +689,7 @@ Object.assign(OCA.Analytics.Dataset.Dataset = {
             .then(response => response.json())
             .then(data => {
                 OCA.Analytics.Wizard.close();
+                data.item_type = 'dataset';
                 OCA.Analytics.Navigation.addNavigationItem(data);
                 const anchor = document.querySelector('#navigationDatasets a[data-id="' + data.id + '"][data-item_type="dataset"]');
                 anchor?.click();

--- a/js/filter.js
+++ b/js/filter.js
@@ -1234,9 +1234,19 @@ OCA.Analytics.Filter.Backend = {
             })
         })
             .then(response => response.json())
+            .then(id => {
+                return fetch(OC.generateUrl('apps/analytics/report/') + id, {
+                    method: 'GET',
+                    headers: OCA.Analytics.headers(),
+                });
+            })
+            .then(response => response.json())
             .then(data => {
-                OCA.Analytics.isNewObject = true;
-                OCA.Analytics.Navigation.init(data);
+                data.item_type = 'report';
+                OCA.Analytics.isNewObject = false;
+                OCA.Analytics.Navigation.addNavigationItem(data);
+                const anchor = document.querySelector('#navigationDatasets a[data-id="' + data.id + '"][data-item_type="report"]');
+                anchor?.click();
             })
             .catch(err => console.error(err));
     },

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -766,6 +766,8 @@ OCA.Analytics.Navigation = {
     },
 
     addNavigationItem: function (item) {
+        if (!item.item_type) item.item_type = 'report';
+
         if (item.item_type === 'dataset') {
             OCA.Analytics.datasets.push(item);
         } else if (item.item_type === 'panorama') {

--- a/js/panorama.js
+++ b/js/panorama.js
@@ -1339,6 +1339,7 @@ Object.assign(OCA.Analytics.Panorama.Backend = {
             })
             .then(response => response.json())
             .then(data => {
+                data.item_type = 'panorama';
                 OCA.Analytics.Navigation.addNavigationItem(data);
                 const anchor = document.querySelector('#navigationDatasets a[data-id="' + data.id + '"][data-item_type="panorama"]');
                 anchor?.click();

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -490,8 +490,18 @@ OCA.Analytics.Sidebar.Report = {
             })
         })
             .then(response => response.json())
+            .then(id => {
+                return fetch(OC.generateUrl('apps/analytics/report/') + id, {
+                    method: 'GET',
+                    headers: OCA.Analytics.headers(),
+                });
+            })
+            .then(response => response.json())
             .then(data => {
-                OCA.Analytics.Navigation.init(data);
+                data.item_type = 'report';
+                OCA.Analytics.Navigation.addNavigationItem(data);
+                const anchor = document.querySelector('#navigationDatasets a[data-id="' + data.id + '"][data-item_type="report"]');
+                anchor?.click();
             });
     },
 
@@ -562,9 +572,19 @@ OCA.Analytics.Sidebar.Report = {
             })
         })
             .then(response => response.json())
+            .then(id => {
+                return fetch(OC.generateUrl('apps/analytics/report/') + id, {
+                    method: 'GET',
+                    headers: OCA.Analytics.headers(),
+                });
+            })
+            .then(response => response.json())
             .then(data => {
                 OCA.Analytics.Wizard.close();
-                OCA.Analytics.Navigation.init(data);
+                data.item_type = 'report';
+                OCA.Analytics.Navigation.addNavigationItem(data);
+                const anchor = document.querySelector('#navigationDatasets a[data-id="' + data.id + '"][data-item_type="report"]');
+                anchor?.click();
             });
     },
 
@@ -578,8 +598,18 @@ OCA.Analytics.Sidebar.Report = {
             })
         })
             .then(response => response.json())
+            .then(id => {
+                return fetch(OC.generateUrl('apps/analytics/report/') + id, {
+                    method: 'GET',
+                    headers: OCA.Analytics.headers(),
+                });
+            })
+            .then(response => response.json())
             .then(data => {
-                OCA.Analytics.Navigation.init(data);
+                data.item_type = 'report';
+                OCA.Analytics.Navigation.addNavigationItem(data);
+                const anchor = document.querySelector('#navigationDatasets a[data-id="' + data.id + '"][data-item_type="report"]');
+                anchor?.click();
             });
     },
 


### PR DESCRIPTION
## Summary
- ensure dynamic dataset/panorama creation sets proper `item_type`
- fetch report details after creation and insert into navigation
- default to `report` when `item_type` is missing
- open new items immediately

## Testing
- `composer install` *(fails: composer not found)*
- `phpunit --version` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac3bf807483338551087e10a2e1e6