### PR TITLE
Expand smart picker results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Show installed version in navigation bar
 - Inline rename for all navigation items
 - Group sharing for panoramas
+- Smart picker shows panoramas and reports with distinct icons
 
 ### Changed
 - Performance tweaks

--- a/js/reference.js
+++ b/js/reference.js
@@ -33,6 +33,6 @@ OCA.Analytics.Reference = {
                 + '<div>' + richObject.subheader + '</div>'
                 //+ '<div style="color: var(--color-text-maxcontrast);">' + richObject.url + '</div>'
                 + '</div></a>';
-        });
+        }, () => {}, { hasInteractiveView: false });
     },
 }

--- a/lib/Reference/ReferenceProvider.php
+++ b/lib/Reference/ReferenceProvider.php
@@ -9,6 +9,7 @@
 namespace OCA\Analytics\Reference;
 
 use OCA\Analytics\Service\ReportService;
+use OCA\Analytics\Service\PanoramaService;
 use OCP\Collaboration\Reference\ADiscoverableReferenceProvider;
 use OCP\Collaboration\Reference\ISearchableReferenceProvider;
 use OCP\Collaboration\Reference\Reference;
@@ -30,6 +31,7 @@ class ReferenceProvider extends ADiscoverableReferenceProvider implements ISearc
     private IURLGenerator $urlGenerator;
     private LoggerInterface $logger;
     private ReportService $ReportService;
+    private PanoramaService $PanoramaService;
 
     public function __construct(IConfig          $config,
                                 LoggerInterface  $logger,
@@ -37,6 +39,7 @@ class ReferenceProvider extends ADiscoverableReferenceProvider implements ISearc
                                 IURLGenerator    $urlGenerator,
                                 ReferenceManager $referenceManager,
                                 ReportService    $ReportService,
+                                PanoramaService  $PanoramaService,
                                 ?string          $userId)
     {
         $this->userId = $userId;
@@ -46,6 +49,7 @@ class ReferenceProvider extends ADiscoverableReferenceProvider implements ISearc
         $this->l10n = $l10n;
         $this->urlGenerator = $urlGenerator;
         $this->ReportService = $ReportService;
+        $this->PanoramaService = $PanoramaService;
     }
 
     public function getId(): string
@@ -81,18 +85,25 @@ class ReferenceProvider extends ADiscoverableReferenceProvider implements ISearc
         if (!$adminLinkPreviewEnabled) {
             //return false;
         }
-        return preg_match('~/apps/analytics/#/r/~', $referenceText) === 1;
+        return preg_match('~/apps/analytics/(?:r|pa)/~', $referenceText) === 1;
     }
 
     public function resolveReference(string $referenceText): ?IReference
     {
         if ($this->matchReference($referenceText)) {
             preg_match("/\d+$/", $referenceText, $matches); // get the last integer
-            $reportMetadata = $this->ReportService->read((int)$matches[0]);
-            if (!empty($reportMetadata)) {
-                $imageUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('analytics', 'app-dark.svg'));
-                $name = $reportMetadata['name'];
-                $subheader = $reportMetadata['subheader'];
+            $isPanorama = str_contains($referenceText, '/pa/');
+            if ($isPanorama) {
+                $item = $this->PanoramaService->read((int)$matches[0]);
+                $icon = 'panorama.svg';
+            } else {
+                $item = $this->ReportService->read((int)$matches[0]);
+                $icon = 'report.svg';
+            }
+            if (!empty($item)) {
+                $imageUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('analytics', $icon));
+                $name = $item['name'];
+                $subheader = $item['subheader'] ?? '';
             } else {
                 $imageUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('analytics', 'noReport.svg'));
                 $name = $this->l10n->t('Report not found');

--- a/lib/Reference/ReferenceProvider.php
+++ b/lib/Reference/ReferenceProvider.php
@@ -59,7 +59,7 @@ class ReferenceProvider extends ADiscoverableReferenceProvider implements ISearc
 
     public function getTitle(): string
     {
-        return $this->l10n->t('Analytics Report');
+        return $this->l10n->t('Analytics');
     }
 
     public function getOrder(): int
@@ -96,14 +96,16 @@ class ReferenceProvider extends ADiscoverableReferenceProvider implements ISearc
             if ($isPanorama) {
                 $item = $this->PanoramaService->read((int)$matches[0]);
                 $icon = 'panorama.svg';
+				$type = $this->l10n->t('Panorama');
             } else {
                 $item = $this->ReportService->read((int)$matches[0]);
                 $icon = 'report.svg';
+				$type = $this->l10n->t('Report');
             }
             if (!empty($item)) {
                 $imageUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('analytics', $icon));
-                $name = $item['name'];
-                $subheader = $item['subheader'] ?? '';
+                $name = $this->l10n->t('Analytics') . ' ' . $type;
+                $subheader = $item['name'];
             } else {
                 $imageUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('analytics', 'noReport.svg'));
                 $name = $this->l10n->t('Report not found');

--- a/lib/Search/SearchProvider.php
+++ b/lib/Search/SearchProvider.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace OCA\Analytics\Search;
 
 use OCA\Analytics\Service\ReportService;
+use OCA\Analytics\Service\PanoramaService;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -30,16 +31,19 @@ class SearchProvider implements IProvider
     /** @var IURLGenerator */
     private $urlGenerator;
     private $ReportService;
+    private $PanoramaService;
 
     public function __construct(IAppManager $appManager,
                                 IL10N $l10n,
                                 IURLGenerator $urlGenerator,
-                                ReportService $ReportService)
+                                ReportService $ReportService,
+                                PanoramaService $PanoramaService)
     {
         $this->appManager = $appManager;
         $this->l10n = $l10n;
         $this->urlGenerator = $urlGenerator;
         $this->ReportService = $ReportService;
+        $this->PanoramaService = $PanoramaService;
     }
 
     public function getId(): string
@@ -53,15 +57,26 @@ class SearchProvider implements IProvider
             return SearchResult::complete($this->getName(), []);
         }
 
-        $datasets = $this->ReportService->search($query->getTerm());
+        $reports = $this->ReportService->search($query->getTerm());
+        $panoramas = $this->PanoramaService->search($query->getTerm());
         $result = [];
 
-        foreach ($datasets as $dataset) {
+        foreach ($reports as $report) {
             $result[] = new SearchResultEntry(
-                $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('analytics', 'app-dark.svg')),
-                $dataset['name'],
+                $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('analytics', 'report.svg')),
+                $report['name'],
                 '',
-                $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute('analytics.page.main') . 'r/' . $dataset['id']),
+                $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute('analytics.page.report', ['id' => $report['id']])),
+                ''
+            );
+        }
+
+        foreach ($panoramas as $panorama) {
+            $result[] = new SearchResultEntry(
+                $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('analytics', 'panorama.svg')),
+                $panorama['name'],
+                '',
+                $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute('analytics.page.panorama', ['id' => $panorama['id']])),
                 ''
             );
         }


### PR DESCRIPTION
## Summary
- make Analytics reference provider recognise new panorama paths and icons
- include panorama metadata when resolving references
- search provider now lists panoramas alongside reports with matching icons
- document smart picker improvements

## Testing
- `php -l lib/Reference/ReferenceProvider.php`
- `php -l lib/Search/SearchProvider.php`
- `composer install` *(fails: CONNECT tunnel failed)*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68874b260c3c83338e446f97e43b31a5