### PR TITLE
Fix threshold coloring in tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 - Shared panorama folders now display their contained panoramas for share recipients
 - Thresholds again highlight matching values in data tables
+- Localized numbers with comma separators now evaluate correctly in thresholds
 
 ## 5.7.1 - 2025-07-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Shared panorama folders now display their contained panoramas for share recipients
+- Thresholds again highlight matching values in data tables
 
 ## 5.7.1 - 2025-07-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Thresholds again highlight matching values in data tables
 - Localized numbers with comma separators now evaluate correctly in thresholds
 - Dashboard widget thresholds now share logic with tables
+- Fixed wrong parameter in widget threshold validation
 
 ## 5.7.1 - 2025-07-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Shared panorama folders now display their contained panoramas for share recipients
 - Thresholds again highlight matching values in data tables
 - Localized numbers with comma separators now evaluate correctly in thresholds
+- Dashboard widget thresholds now share logic with tables
 
 ## 5.7.1 - 2025-07-15
 ### Fixed

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -183,7 +183,8 @@ OCA.Analytics.Dashboard = {
             type = 'table';
         }
 
-        let widgetRow = OCA.Analytics.Dashboard.buildWidgetRow(report, reportId, subheader, value, jsondata.thresholds);
+        // pass dimension index 0 for threshold evaluation
+        let widgetRow = OCA.Analytics.Dashboard.buildWidgetRow(report, reportId, subheader, value, jsondata.thresholds, 0);
         document.getElementById('analyticsWidgetItem-report-' + reportId).insertAdjacentHTML('beforeend', widgetRow);
         document.getElementById('analyticsWidgetItem-report-' + reportId).addEventListener('click', OCA.Analytics.Dashboard.handleNavigationClicked);
 
@@ -198,8 +199,8 @@ OCA.Analytics.Dashboard = {
         }
     },
 
-    buildWidgetRow: function (report, reportId, subheader, value, thresholds) {
-        let thresholdColor = OCA.Analytics.Dashboard.validateThreshold(subheader, value, thresholds);
+    buildWidgetRow: function (report, reportId, subheader, value, thresholds, dimension) {
+        let thresholdColor = OCA.Analytics.Dashboard.validateThreshold(dimension, value, thresholds);
         //value = parseFloat(value).toLocaleString();
         value = OCA.Analytics.Dashboard.nFormatter(value);
         let href = OC.generateUrl('apps/analytics/r/' + reportId);
@@ -246,8 +247,30 @@ OCA.Analytics.Dashboard = {
         return num;
     },
 
-    validateThreshold: function (kpi, value, thresholds) {
-        const colorStyle = OCA.Analytics.Visualization.validateThreshold(kpi, value, thresholds);
+    // Evaluate thresholds for the given dimension index and return inline style
+    validateThreshold: function (dimension, value, thresholds) {
+        thresholds = thresholds.filter(t => parseInt(t.dimension) === dimension);
+        let colorStyle;
+
+        for (let threshold of thresholds) {
+            let option = String(threshold.option).toUpperCase();
+            const map = {'=':'EQ','>':'GT','<':'LT','>=':'GE','<=':'LE','!=':'NE'};
+            option = map[option] || option;
+
+            const comparison = OCA.Analytics.Visualization.thresholdOperators[option](value, threshold.value);
+            const severity = parseInt(threshold.severity);
+
+            if (comparison === true) {
+                if (severity === 2) {
+                    colorStyle = 'color: ' + OCA.Analytics.Visualization.thresholdColorNumberRed;
+                } else if (severity === 3) {
+                    colorStyle = 'color: ' + OCA.Analytics.Visualization.thresholdColorNumberOrange;
+                } else if (severity === 4) {
+                    colorStyle = 'color: ' + OCA.Analytics.Visualization.thresholdColorNumberGreen;
+                }
+            }
+        }
+
         return colorStyle ? `style="${colorStyle}"` : '';
     },
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -183,8 +183,8 @@ OCA.Analytics.Dashboard = {
             type = 'table';
         }
 
-        // pass dimension index 0 for threshold evaluation
-        let widgetRow = OCA.Analytics.Dashboard.buildWidgetRow(report, reportId, subheader, value, jsondata.thresholds, 0);
+        // pass the last dimension index for threshold evaluation
+        let widgetRow = OCA.Analytics.Dashboard.buildWidgetRow(report, reportId, subheader, value, jsondata.thresholds, data.length - 1);
         document.getElementById('analyticsWidgetItem-report-' + reportId).insertAdjacentHTML('beforeend', widgetRow);
         document.getElementById('analyticsWidgetItem-report-' + reportId).addEventListener('click', OCA.Analytics.Dashboard.handleNavigationClicked);
 
@@ -200,7 +200,7 @@ OCA.Analytics.Dashboard = {
     },
 
     buildWidgetRow: function (report, reportId, subheader, value, thresholds, dimension) {
-        let thresholdColor = OCA.Analytics.Dashboard.validateThreshold(dimension, value, thresholds);
+        let thresholdColor = OCA.Analytics.Visualization.validateThreshold(dimension, value, thresholds);
         //value = parseFloat(value).toLocaleString();
         value = OCA.Analytics.Dashboard.nFormatter(value);
         let href = OC.generateUrl('apps/analytics/r/' + reportId);
@@ -212,7 +212,7 @@ OCA.Analytics.Dashboard = {
                 </div>
                 <div class="analyticsWidgetContent2">
                      <div id="kpi${reportId}">
-                        <div ${thresholdColor} class="analyticsWidgetValue">${value}</div>
+                        <div style="${thresholdColor}" class="analyticsWidgetValue">${value}</div>
                     </div>
                    <div id="chartContainer${reportId}">
                         <canvas id="myChart${reportId}" class="chartContainer"></canvas>
@@ -245,33 +245,6 @@ OCA.Analytics.Dashboard = {
             return (num / 1000).toFixed(1).replace(/\.0$/, '') + 'K';
         }
         return num;
-    },
-
-    // Evaluate thresholds for the given dimension index and return inline style
-    validateThreshold: function (dimension, value, thresholds) {
-        thresholds = thresholds.filter(t => parseInt(t.dimension) === dimension);
-        let colorStyle;
-
-        for (let threshold of thresholds) {
-            let option = String(threshold.option).toUpperCase();
-            const map = {'=':'EQ','>':'GT','<':'LT','>=':'GE','<=':'LE','!=':'NE'};
-            option = map[option] || option;
-
-            const comparison = OCA.Analytics.Visualization.thresholdOperators[option](value, threshold.value);
-            const severity = parseInt(threshold.severity);
-
-            if (comparison === true) {
-                if (severity === 2) {
-                    colorStyle = 'color: ' + OCA.Analytics.Visualization.thresholdColorNumberRed;
-                } else if (severity === 3) {
-                    colorStyle = 'color: ' + OCA.Analytics.Visualization.thresholdColorNumberOrange;
-                } else if (severity === 4) {
-                    colorStyle = 'color: ' + OCA.Analytics.Visualization.thresholdColorNumberGreen;
-                }
-            }
-        }
-
-        return colorStyle ? `style="${colorStyle}"` : '';
     },
 
     buildChart: function (jsondata) {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -247,45 +247,8 @@ OCA.Analytics.Dashboard = {
     },
 
     validateThreshold: function (kpi, value, thresholds) {
-        const operators = {
-            '=': function (a, b) {
-                return a === b
-            },
-            '<': function (a, b) {
-                return a < b
-            },
-            '>': function (a, b) {
-                return a > b
-            },
-            '<=': function (a, b) {
-                return a <= b
-            },
-            '>=': function (a, b) {
-                return a >= b
-            },
-            '!=': function (a, b) {
-                return a !== b
-            },
-        };
-        let thresholdColor;
-
-        thresholds = thresholds.filter(p => p.dimension1 === kpi || p.dimension1 === '*');
-
-        for (let threshold of thresholds) {
-            const comparison = operators[threshold['option']](parseFloat(value), parseFloat(threshold['value']));
-            threshold['severity'] = parseInt(threshold['severity']);
-            if (comparison === true) {
-                if (threshold['severity'] === 2) {
-                    thresholdColor = 'style="color: red;"';
-                } else if (threshold['severity'] === 3) {
-                    thresholdColor = 'style="color: orange;"';
-                } else if (threshold['severity'] === 4) {
-                    thresholdColor = 'style="color: green;"';
-                }
-            }
-        }
-
-        return thresholdColor;
+        const colorStyle = OCA.Analytics.Visualization.validateThreshold(kpi, value, thresholds);
+        return colorStyle ? `style="${colorStyle}"` : '';
     },
 
     buildChart: function (jsondata) {

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -569,7 +569,8 @@ OCA.Analytics.Visualization = {
             value = rawValue.toLocaleString(undefined, { minimumFractionDigits: 2 });
         }
 
-        let thresholdColor = OCA.Analytics.Visualization.validateThreshold(kpi, value, jsondata.thresholds);
+        let dimension = jsondata.data[0].length - 1
+        let thresholdColor = OCA.Analytics.Visualization.validateThreshold(dimension, value, jsondata.thresholds);
 
         // Create the KPI content dynamically
         const kpiContent = document.createElement('div');
@@ -1237,15 +1238,15 @@ OCA.Analytics.Visualization = {
     /**
      * Check a value against threshold rules and return a color style.
      *
-     * @param {string} kpi - Name of the metric
+     * @param {string} dimension - Column index
      * @param {number|string} value - Value to check
      * @param {Array} thresholds - Threshold definitions
      * @returns {string|undefined} CSS color style
      */
-    validateThreshold: function (kpi, value, thresholds) {
+    validateThreshold: function (dimension, value, thresholds) {
         let thresholdColor;
 
-        thresholds = thresholds.filter(p => p.dimension1 === kpi || p.dimension1 === '*');
+        thresholds = thresholds.filter(p => p.dimension === dimension);
 
         for (let threshold of thresholds) {
             let option = String(threshold['option']).toUpperCase();

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -53,11 +53,36 @@ OCA.Analytics.Visualization = {
     compareValues: function(a, b, fn) {
         function normalizeNumberString(str) {
             if (typeof str !== "string") return str;
-            // Remove all '.' as thousands separator
-            let cleaned = str.replace(/\./g, '');
-            // Replace ',' with '.' as decimal separator for parseFloat
-            cleaned = cleaned.replace(/,/g, '.');
-            return cleaned;
+            str = str.trim();
+            const hasComma = str.includes(',');
+            const hasDot = str.includes('.');
+
+            if (hasComma && hasDot) {
+                if (str.lastIndexOf(',') > str.lastIndexOf('.')) {
+                    // comma as decimal separator
+                    str = str.replace(/\./g, '');
+                    str = str.replace(',', '.');
+                } else {
+                    // dot as decimal separator
+                    str = str.replace(/,/g, '');
+                }
+            } else if (hasComma) {
+                const idx = str.lastIndexOf(',');
+                const digits = str.length - idx - 1;
+                if (digits <= 2) {
+                    str = str.replace(',', '.');
+                } else {
+                    str = str.replace(/,/g, '');
+                }
+            } else if (hasDot) {
+                const idx = str.lastIndexOf('.');
+                const digits = str.length - idx - 1;
+                if (digits > 2) {
+                    str = str.replace(/\./g, '');
+                }
+            }
+
+            return str.replace(/\s/g, '');
         }
 
         const normA = normalizeNumberString(String(a));

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -421,7 +421,7 @@ OCA.Analytics.Visualization = {
                     } else if (severity === 3) { // orange
                         color = OCA.Analytics.Visualization.thresholdColorNumberOrange;
                     } else if (severity === 4) { // green
-                        color = OCA.Analytics.Visualization.thresholdColorNumberOrange;
+                        color = OCA.Analytics.Visualization.thresholdColorNumberGreen;
                     }
                     const cell = row.childNodes.item(dimIndex);
                     if (cell) {
@@ -1238,11 +1238,11 @@ OCA.Analytics.Visualization = {
             threshold['severity'] = parseInt(threshold['severity']);
             if (comparison === true) {
                 if (threshold['severity'] === 2) {
-                    thresholdColor = 'color: ' . OCA.Analytics.Visualization.thresholdColorNumberRed;
+                    thresholdColor = 'color: ' + OCA.Analytics.Visualization.thresholdColorNumberRed;
                 } else if (threshold['severity'] === 3) {
-                    thresholdColor = 'color: ' . OCA.Analytics.Visualization.thresholdColorNumberOrange;
+                    thresholdColor = 'color: ' + OCA.Analytics.Visualization.thresholdColorNumberOrange;
                 } else if (threshold['severity'] === 4) {
-                    thresholdColor = 'color: ' . OCA.Analytics.Visualization.thresholdColorNumberGreen;
+                    thresholdColor = 'color: ' + OCA.Analytics.Visualization.thresholdColorNumberGreen;
                 }
             }
         }

--- a/lib/Service/ThresholdService.php
+++ b/lib/Service/ThresholdService.php
@@ -93,13 +93,38 @@ class ThresholdService {
 		}
 	}
 
-	private function normalizeNumberString(string $str): string {
-		// Remove thousands separators (e.g., '.')
-		$str = str_replace('.', '', $str);
-		// Replace decimal separator (e.g., ',') with '.'
-		$str = str_replace(',', '.', $str);
-		return $str;
-	}
+       private function normalizeNumberString(string $str): string {
+               $str = trim($str);
+               $hasComma = str_contains($str, ',');
+               $hasDot   = str_contains($str, '.');
+
+               if ($hasComma && $hasDot) {
+                       if (strrpos($str, ',') > strrpos($str, '.')) {
+                               // comma as decimal separator
+                               $str = str_replace('.', '', $str);
+                               $str = str_replace(',', '.', $str);
+                       } else {
+                               // dot as decimal separator
+                               $str = str_replace(',', '', $str);
+                       }
+               } elseif ($hasComma) {
+                       $idx = strrpos($str, ',');
+                       $digits = strlen($str) - $idx - 1;
+                       if ($digits <= 2) {
+                               $str = str_replace(',', '.', $str);
+                       } else {
+                               $str = str_replace(',', '', $str);
+                       }
+               } elseif ($hasDot) {
+                       $idx = strrpos($str, '.');
+                       $digits = strlen($str) - $idx - 1;
+                       if ($digits > 2) {
+                               $str = str_replace('.', '', $str);
+                       }
+               }
+
+               return str_replace(' ', '', $str);
+       }
 
 	/**
 	 * Compare two values and return comparison result similar to spaceship operator

--- a/tests/Service/ThresholdServiceTest.php
+++ b/tests/Service/ThresholdServiceTest.php
@@ -104,13 +104,19 @@ class ThresholdServiceTest extends TestCase {
 				'10.11', 20, 20,
 				true,
 			],
-			'decimal false' => [
-				[['id' => 1, 'dimension' => 0, 'option' => 'LT', 'target' => '10', 'user_id' => 'u1']],
-				['id' => 1, 'name' => 'Report A', 'dimension1' => 'amount', 'dimension2' => '', 'value' => ''],
-				'10.11', 20, 20,
-				false,
-			],
-			// Add more scenarios here …
-		];
-	}
+                        'decimal false' => [
+                                [['id' => 1, 'dimension' => 0, 'option' => 'LT', 'target' => '10', 'user_id' => 'u1']],
+                                ['id' => 1, 'name' => 'Report A', 'dimension1' => 'amount', 'dimension2' => '', 'value' => ''],
+                                '10.11', 20, 20,
+                                false,
+                        ],
+                        'thousands comma' => [
+                                [['id' => 1, 'dimension' => 0, 'option' => 'GT', 'target' => '5000', 'user_id' => 'u1']],
+                                ['id' => 1, 'name' => 'Report A', 'dimension1' => 'amount', 'dimension2' => '', 'value' => ''],
+                                '6,063', 20, 20,
+                                true,
+                        ],
+                        // Add more scenarios here …
+                ];
+        }
 }


### PR DESCRIPTION
## Summary
- fix color logic for severity 4 in data table highlighting
- correct string concatenation in threshold validation

## Testing
- `phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68877b0fd3a483339fa1798266f02a44