### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -74,7 +74,7 @@ class ActivityManager
      * @param $eventSubject
      * @param string|null $user_id
      */
-    public function triggerEvent($datasetId, $eventType, $eventSubject, string $user_id = null)
+    public function triggerEvent($datasetId, $eventType, $eventSubject, ?string $user_id = null)
     {
         try {
             $event = $this->createEvent($datasetId, $eventType, $eventSubject, $user_id);
@@ -95,7 +95,7 @@ class ActivityManager
      * @return IEvent
      * @throws \OCP\DB\Exception
      */
-    private function createEvent($objectId, $eventType, $eventSubject, string $user_id = null)
+    private function createEvent($objectId, $eventType, $eventSubject, ?string $user_id = null)
     {
         if ($eventType === ActivityManager::OBJECT_REPORT) {
             $name = $objectId !== 0 ? $this->ReportMapper->readOwn($objectId)['name'] : '';

--- a/lib/Controller/DatasourceController.php
+++ b/lib/Controller/DatasourceController.php
@@ -85,7 +85,7 @@ class DatasourceController extends Controller {
 	 * @param int|null $datasourceType
 	 * @return array
 	 */
-	public function index(int $datasourceType = null) {
+	public function index(?int $datasourceType = null) {
 		$result = [];
 		$datasourceIndex = $this->getDatasources($datasourceType);
 
@@ -110,7 +110,7 @@ class DatasourceController extends Controller {
 	 * @param int|null $datasourceType
 	 * @return array
 	 */
-	public function indexFiltered(int $datasourceType = null) {
+	public function indexFiltered(?int $datasourceType = null) {
 		return $this->index($datasourceType);
 	}
 
@@ -192,7 +192,7 @@ class DatasourceController extends Controller {
 	 * @param int|null $datasourceType
 	 * @return array
 	 */
-	private function getDatasources(int $datasourceType = null) {
+	private function getDatasources(?int $datasourceType = null) {
 		$datasources = $this->getOwnDatasources($datasourceType) + $this->getRegisteredDatasources($datasourceType);
 
 		// Data sources can be disabled globally by their ID
@@ -209,7 +209,7 @@ class DatasourceController extends Controller {
 	 * @param int|null $datasourceType
 	 * @return array
 	 */
-	private function getOwnDatasources(int $datasourceType = null) {
+	private function getOwnDatasources(?int $datasourceType = null) {
 		$dataSources = [];
 		$serviceMapping = [
 			self::DATASET_TYPE_GIT => $this->GithubService,
@@ -235,7 +235,7 @@ class DatasourceController extends Controller {
 	 * @param int|null $datasourceType
 	 * @return array
 	 */
-	private function getRegisteredDatasources(int $datasourceType = null) {
+	private function getRegisteredDatasources(?int $datasourceType = null) {
 		$dataSources = [];
 		$event = new DatasourceEvent();
 		$this->dispatcher->dispatchTyped($event);

--- a/lib/Controller/ReportController.php
+++ b/lib/Controller/ReportController.php
@@ -248,7 +248,7 @@ class ReportController extends Controller
      * @throws \OCP\Files\NotFoundException
      * @throws \OCP\Files\NotPermittedException
      */
-    public function import(string $path = null, string $raw = null)
+    public function import(?string $path = null, ?string $raw = null)
     {
         return new DataResponse($this->ReportService->import($path, $raw));
     }

--- a/lib/Db/StorageMapper.php
+++ b/lib/Db/StorageMapper.php
@@ -49,7 +49,7 @@ class StorageMapper
      * @return string
      * @throws Exception
      */
-    public function create(int $datasetId, $dimension1, $dimension2, $value, string $user_id = null, $timestamp = null, $bulkInsert = null, $aggregation = null)
+    public function create(int $datasetId, $dimension1, $dimension2, $value, ?string $user_id = null, $timestamp = null, $bulkInsert = null, $aggregation = null)
     {
         $dimension1 = $dimension1 !== null ? str_replace('*', '', $dimension1) : null;
         $dimension2 = $dimension2 !== null ? str_replace('*', '', $dimension2) : null;
@@ -220,7 +220,7 @@ class StorageMapper
      * @return bool
      * @throws Exception
      */
-    public function delete(int $datasetId, $dimension1, $dimension2, string $user_id = null)
+    public function delete(int $datasetId, $dimension1, $dimension2, ?string $user_id = null)
     {
         if ($user_id) $this->userId = $user_id;
 
@@ -346,7 +346,7 @@ class StorageMapper
      * @return array
      * @throws Exception
      */
-    public function getRecordCount(int $datasetId, string $user_id = null)
+    public function getRecordCount(int $datasetId, ?string $user_id = null)
     {
         if ($user_id) $this->userId = $user_id;
         $sql = $this->db->getQueryBuilder();

--- a/lib/Service/ReportService.php
+++ b/lib/Service/ReportService.php
@@ -364,7 +364,7 @@ class ReportService {
 	 * @throws \OCP\Files\NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
 	 */
-	public function import(string $path = null, string $raw = null) {
+	public function import(?string $path = null, ?string $raw = null) {
 		if ($path !== '' and $path !== null) {
 			$file = $this->rootFolder->getUserFolder($this->userId)->get($path);
 			$data = $file->getContent();

--- a/lib/Service/StorageService.php
+++ b/lib/Service/StorageService.php
@@ -107,7 +107,7 @@ class StorageService {
 			   $dimension1,
 			   $dimension2,
 			   $value,
-		string $user_id = null,
+			   ?string $user_id = null,
 			   $bulkInsert = null,
 			   $aggregation = null
 	) {
@@ -165,7 +165,7 @@ class StorageService {
 	 * @param string|null $user_id
 	 * @return bool
 	 */
-	public function delete(int $datasetId, $dimension1, $dimension2, string $user_id = null) {
+	public function delete(int $datasetId, $dimension1, $dimension2, ?string $user_id = null) {
 		return $this->StorageMapper->delete($datasetId, $dimension1, $dimension2, $user_id);
 	}
 
@@ -189,7 +189,7 @@ class StorageService {
 	 * @NoAdminRequired
 	 * @param int $datasetId
 	 * @param $filter
-	 * @return bool
+	 * @return int
 	 * @throws Exception
 	 */
 	public function deleteWithFilter(int $datasetId, $filter) {
@@ -215,7 +215,7 @@ class StorageService {
 	 * @param string|null $user_id
 	 * @return array
 	 */
-	public function getRecordCount(int $datasetId, string $user_id = null) {
+	public function getRecordCount(int $datasetId, ?string $user_id = null) {
 		return $this->StorageMapper->getRecordCount($datasetId, $user_id);
 	}
 


### PR DESCRIPTION
Implicitly marking parameter xx as nullable is deprecated, the explicit nullable type must be used instead.