### PR TITLE
Cache report data in the browser (using ETag & If-None-Match)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
+## 5.9.0 - 2025-08-xx
 ### Added
-- Cache report data using `If-Modified-Since` to avoid unnecessary processing
+- Cache report data in the browser (using ETag & If-None-Match) #535
 
 ### Fixed
-- Refetch report data if the server responds with `304 Not Modified` but no cache is present
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)
 
 ## 5.8.0 - 2025-07-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
+### Added
+- Cache report data using `If-Modified-Since` to avoid unnecessary processing
+
 ### Fixed
+- Refetch report data if the server responds with `304 Not Modified` but no cache is present
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)
 
 ## 5.8.0 - 2025-07-29

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -22,8 +22,8 @@ return [
 		['name' => 'report#create', 'url' => '/report', 'verb' => 'POST'],
 		['name' => 'report#read', 'url' => '/report/{reportId}', 'verb' => 'GET'],
 		['name' => 'report#delete', 'url' => '/report/{reportId}', 'verb' => 'DELETE'],
-                ['name' => 'report#update', 'url' => '/report/{reportId}', 'verb' => 'PUT'],
-                ['name' => 'report#rename', 'url' => '/report/{reportId}/rename', 'verb' => 'PUT'],
+		['name' => 'report#update', 'url' => '/report/{reportId}', 'verb' => 'PUT'],
+		['name' => 'report#rename', 'url' => '/report/{reportId}/rename', 'verb' => 'PUT'],
 		['name' => 'report#createCopy', 'url' => '/report/copy', 'verb' => 'POST'],
 		['name' => 'report#createFromDataFile', 'url' => '/report/file', 'verb' => 'POST'],
 		['name' => 'report#updateOptions', 'url' => '/report/{reportId}/options', 'verb' => 'POST'],
@@ -38,24 +38,24 @@ return [
 		['name' => 'dataset#index', 'url' => '/dataset', 'verb' => 'GET'],
 		['name' => 'dataset#create', 'url' => '/dataset', 'verb' => 'POST'],
 		['name' => 'dataset#read', 'url' => '/dataset/{datasetId}', 'verb' => 'GET'],
-                ['name' => 'dataset#delete', 'url' => '/dataset/{datasetId}', 'verb' => 'DELETE'],
-                ['name' => 'dataset#update', 'url' => '/dataset/{datasetId}', 'verb' => 'PUT'],
-                ['name' => 'dataset#rename', 'url' => '/dataset/{datasetId}/rename', 'verb' => 'PUT'],
-                ['name' => 'dataset#updateGroup', 'url' => '/dataset/{datasetId}/group', 'verb' => 'POST'],
-                ['name' => 'dataset#createGroup', 'url' => '/dataset/group', 'verb' => 'POST'],
-                ['name' => 'dataset#status', 'url' => '/dataset/{datasetId}/status', 'verb' => 'GET'],
-                ['name' => 'dataset#provider', 'url' => '/dataset/{datasetId}/provider', 'verb' => 'POST'],
+		['name' => 'dataset#delete', 'url' => '/dataset/{datasetId}', 'verb' => 'DELETE'],
+		['name' => 'dataset#update', 'url' => '/dataset/{datasetId}', 'verb' => 'PUT'],
+		['name' => 'dataset#rename', 'url' => '/dataset/{datasetId}/rename', 'verb' => 'PUT'],
+		['name' => 'dataset#updateGroup', 'url' => '/dataset/{datasetId}/group', 'verb' => 'POST'],
+		['name' => 'dataset#createGroup', 'url' => '/dataset/group', 'verb' => 'POST'],
+		['name' => 'dataset#status', 'url' => '/dataset/{datasetId}/status', 'verb' => 'GET'],
+		['name' => 'dataset#provider', 'url' => '/dataset/{datasetId}/provider', 'verb' => 'POST'],
 
 		// Panorama
 		['name' => 'panorama#index', 'url' => '/panorama', 'verb' => 'GET'],
 		['name' => 'panorama#create', 'url' => '/panorama', 'verb' => 'POST'],
 		['name' => 'panorama#read', 'url' => '/panorama/{panoramaId}', 'verb' => 'GET'],
-                ['name' => 'panorama#delete', 'url' => '/panorama/{panoramaId}', 'verb' => 'DELETE'],
-                ['name' => 'panorama#update', 'url' => '/panorama/{panoramaId}', 'verb' => 'PUT'],
-                ['name' => 'panorama#rename', 'url' => '/panorama/{panoramaId}/rename', 'verb' => 'PUT'],
-                ['name' => 'panorama#updateGroup', 'url' => '/panorama/{panoramaId}/group', 'verb' => 'POST'],
-                ['name' => 'panorama#createGroup', 'url' => '/panorama/group', 'verb' => 'POST'],
-                ['name' => 'panorama#getOwnFavoriteReports', 'url' => '/panoramaFavorites', 'verb' => 'GET'],
+		['name' => 'panorama#delete', 'url' => '/panorama/{panoramaId}', 'verb' => 'DELETE'],
+		['name' => 'panorama#update', 'url' => '/panorama/{panoramaId}', 'verb' => 'PUT'],
+		['name' => 'panorama#rename', 'url' => '/panorama/{panoramaId}/rename', 'verb' => 'PUT'],
+		['name' => 'panorama#updateGroup', 'url' => '/panorama/{panoramaId}/group', 'verb' => 'POST'],
+		['name' => 'panorama#createGroup', 'url' => '/panorama/group', 'verb' => 'POST'],
+		['name' => 'panorama#getOwnFavoriteReports', 'url' => '/panoramaFavorites', 'verb' => 'GET'],
 		['name' => 'panorama#setFavorite', 'url' => '/panoramaFavorite/{panoramaId}', 'verb' => 'POST'],
 
 		// Data Output
@@ -93,9 +93,9 @@ return [
 
 		// Threshold
 		['name' => 'threshold#create', 'url' => '/threshold', 'verb' => 'POST'],
-                ['name' => 'threshold#read', 'url' => '/threshold/{reportId}', 'verb' => 'GET'],
-                ['name' => 'threshold#delete', 'url' => '/threshold/{thresholdId}', 'verb' => 'DELETE'],
-                ['name' => 'threshold#reorder', 'url' => '/threshold/order/{reportId}', 'verb' => 'PUT'],
+		['name' => 'threshold#read', 'url' => '/threshold/{reportId}', 'verb' => 'GET'],
+		['name' => 'threshold#delete', 'url' => '/threshold/{thresholdId}', 'verb' => 'DELETE'],
+		['name' => 'threshold#reorder', 'url' => '/threshold/order/{reportId}', 'verb' => 'PUT'],
 
 		// API
 		// V1

--- a/js/report.js
+++ b/js/report.js
@@ -86,6 +86,9 @@ Object.assign(OCA.Analytics.Report, {
      * Render report data as chart or table
      */
     buildReport: function () {
+        OCA.Analytics.Visualization.hideElement('analytics-loading');
+        OCA.Analytics.Visualization.showElement('analytics-content-report');
+
         document.getElementById('reportHeader').innerText = OCA.Analytics.currentReportData.options.name;
         if (OCA.Analytics.currentReportData.options.subheader !== '') {
             document.getElementById('reportSubHeader').innerText = OCA.Analytics.currentReportData.options.subheader;
@@ -784,152 +787,115 @@ Object.assign(OCA.Analytics.Report.Backend = {
         if (OCA.Analytics.currentXhrRequest) OCA.Analytics.currentXhrRequest.abort();
         OCA.Analytics.Report.resetContentArea();
 
-        let url;
-        let cacheKey;
-        if (document.getElementById('sharingToken').value === '') {
-            const reportId = document.querySelector('#navigationDatasets .active').firstElementChild.dataset.id;
-            url = OC.generateUrl('apps/analytics/data/') + reportId;
-            cacheKey = `analytics-report-${reportId}`;
-        } else {
-            const token = document.getElementById('sharingToken').value;
-            url = OC.generateUrl('apps/analytics/data/public/') + token;
-            cacheKey = `analytics-report-public-${token}`;
-        }
+        // Build AJAX parameters from filter options
+        const ajaxData = ['filteroptions', 'dataoptions', 'chartoptions', 'tableoptions'].reduce((acc, option) => {
+            if (OCA.Analytics.currentReportData.options?.[option]) {
+                acc[option] = JSON.stringify(OCA.Analytics.currentReportData.options[option]);
+            }
+            return acc;
+        }, {});
 
-        // read cached data and timestamp from local storage
+        const sharingToken = document.getElementById('sharingToken').value;
+        const isPublic = sharingToken !== '';
+        const reportId = isPublic ? sharingToken : document.querySelector('#navigationDatasets .active').firstElementChild.dataset.id;
+        const url = OC.generateUrl(`apps/analytics/data/${isPublic ? 'public/' : ''}`) + reportId;
+        const cacheKey = `analytics-report-${reportId}`;
+
+        // Retrieve cached data and version
         let cachedData = null;
-        let cachedTimestamp = null;
-        const cachedEntry = localStorage.getItem(cacheKey);
-        if (cachedEntry) {
-            try {
+        let cachedVersion = null;
+        try {
+            const cachedEntry = localStorage.getItem(cacheKey);
+            if (cachedEntry) {
                 const parsed = JSON.parse(cachedEntry);
                 cachedData = parsed.data;
-                cachedTimestamp = parsed.lastModified;
-            } catch (e) {
-                // ignore invalid cache entries
+                cachedVersion = parsed.version;
             }
+        } catch (e) {
+            localStorage.removeItem(cacheKey);
         }
 
-        // send user current filter options to the data request;
-        // if nothing is changed by the user, the filter which is stored for the report, will be used
-        let ajaxData = {};
-        if (typeof (OCA.Analytics.currentReportData.options) !== 'undefined') {
-            if (typeof (OCA.Analytics.currentReportData.options.filteroptions) !== 'undefined') {
-                ajaxData.filteroptions = JSON.stringify(OCA.Analytics.currentReportData.options.filteroptions);
-            }
-            if (typeof (OCA.Analytics.currentReportData.options.dataoptions) !== 'undefined') {
-                ajaxData.dataoptions = JSON.stringify(OCA.Analytics.currentReportData.options.dataoptions);
-            }
-            if (typeof (OCA.Analytics.currentReportData.options.chartoptions) !== 'undefined') {
-                ajaxData.chartoptions = JSON.stringify(OCA.Analytics.currentReportData.options.chartoptions);
-            }
-            if (typeof (OCA.Analytics.currentReportData.options.tableoptions) !== 'undefined') {
-                ajaxData.tableoptions = JSON.stringify(OCA.Analytics.currentReportData.options.tableoptions);
-            }
-        }
-
-        // using xmlhttprequest in this place as long running requests need to be aborted
-        // abort() is not possible for fetch()
         let xhr = new XMLHttpRequest();
         let params = new URLSearchParams(ajaxData);
         let requestUrl = `${url}?${params}`;
-
         xhr.open('GET', requestUrl, true);
         xhr.setRequestHeader('requesttoken', OC.requestToken);
         xhr.setRequestHeader('OCS-APIREQUEST', 'true');
-        if (cachedTimestamp) {
-            xhr.setRequestHeader('If-Modified-Since', cachedTimestamp);
+
+        // if data for that report is cached locally, send the version to the backend
+        if (cachedVersion) {
+            xhr.setRequestHeader('If-None-Match', cachedVersion );
         }
+
         OCA.Analytics.currentXhrRequest = xhr;
 
-        const handleData = function (data) {
-            // Do something with the data here
-
-            OCA.Analytics.Visualization.hideElement('analytics-loading');
-            OCA.Analytics.Visualization.showElement('analytics-content-report');
-
-            OCA.Analytics.currentReportData = data;
-            try {
-                // Chart.js v4.4.3 changed from xAxes to x. In case the user has old chart options, they need to be corrected
-                let parsedChartOptions = JSON.parse(OCA.Analytics.currentReportData.options.chartoptions.replace(/xAxes/g, 'x'));
-                OCA.Analytics.currentReportData.options.chartoptions = (parsedChartOptions !== null && typeof parsedChartOptions === 'object') ? parsedChartOptions : {};
-            } catch (e) {
-                OCA.Analytics.currentReportData.options.chartoptions = {};
-            }
-
-            try {
-                let parsedDataOptions = JSON.parse(OCA.Analytics.currentReportData.options.dataoptions);
-                OCA.Analytics.currentReportData.options.dataoptions = (parsedDataOptions !== null && typeof parsedDataOptions === 'object') ? parsedDataOptions : {};
-            } catch (e) {
-                OCA.Analytics.currentReportData.options.dataoptions = {};
-            }
-
-            try {
-                let parsedFilterOptions = JSON.parse(OCA.Analytics.currentReportData.options.filteroptions);
-                OCA.Analytics.currentReportData.options.filteroptions = (parsedFilterOptions !== null && typeof parsedFilterOptions === 'object') ? parsedFilterOptions : {};
-            } catch (e) {
-                OCA.Analytics.currentReportData.options.filteroptions = {};
-            }
-
-            try {
-                let parsedTableOptions = JSON.parse(OCA.Analytics.currentReportData.options.tableoptions);
-                OCA.Analytics.currentReportData.options.tableoptions = (parsedTableOptions !== null && typeof parsedTableOptions === 'object') ? parsedTableOptions : {};
-            } catch (e) {
-                OCA.Analytics.currentReportData.options.tableoptions = {};
-            }
-
-            document.getElementById('reportHeader').innerText = data.options.name;
-            if (data.options.subheader !== '') {
-                document.getElementById('reportSubHeader').innerText = data.options.subheader;
-                OCA.Analytics.Visualization.showElement('reportSubHeader');
-            }
-
-            // if the user uses a special time parser (e.g. DD.MM), the data needs to be sorted differently
-            OCA.Analytics.currentReportData = OCA.Analytics.Visualization.sortDates(OCA.Analytics.currentReportData);
-            OCA.Analytics.currentReportData = OCA.Analytics.Visualization.applyTimeAggregation(OCA.Analytics.currentReportData);
-            OCA.Analytics.currentReportData = OCA.Analytics.Visualization.applyTopN(OCA.Analytics.currentReportData);
-
-            OCA.Analytics.Report.buildReport();
-
-            let refresh = parseInt(OCA.Analytics.currentReportData.options.refresh);
-            OCA.Analytics.Report.Backend.startRefreshTimer(refresh);
-        };
-
         xhr.onreadystatechange = function () {
-            if (xhr.readyState === 4) {
+            if (xhr.readyState === XMLHttpRequest.DONE) {
                 if (xhr.status === 200) {
-                    let data = JSON.parse(xhr.responseText);
-                    const lastMod = xhr.getResponseHeader('Last-Modified');
-                    if (lastMod) {
-                        localStorage.setItem(cacheKey, JSON.stringify({ data: data, lastModified: lastMod }));
+                    const data = JSON.parse(xhr.responseText);
+                    // derive new version from ETag
+                    const newVersion = xhr.getResponseHeader('ETag') || null;
+                    // data needs to be marked as cacheable
+                    const cacheable = xhr.getResponseHeader('X-Analytics-Cacheable') === 'true';
+
+                    if (cacheable && newVersion) {
+                        localStorage.setItem(cacheKey, JSON.stringify({ data, version: newVersion }));
                     }
-                    handleData(data);
-                } else if (xhr.status === 304) {
-                    if (cachedData) {
-                        handleData(cachedData);
-                    } else {
-                        localStorage.removeItem(cacheKey);
-                        let fallbackXhr = new XMLHttpRequest();
-                        fallbackXhr.open('GET', requestUrl, true);
-                        fallbackXhr.setRequestHeader('requesttoken', OC.requestToken);
-                        fallbackXhr.setRequestHeader('OCS-APIREQUEST', 'true');
-                        fallbackXhr.onreadystatechange = function () {
-                            if (fallbackXhr.readyState === 4 && fallbackXhr.status === 200) {
-                                let data = JSON.parse(fallbackXhr.responseText);
-                                const lastMod = fallbackXhr.getResponseHeader('Last-Modified');
-                                if (lastMod) {
-                                    localStorage.setItem(cacheKey, JSON.stringify({ data: data, lastModified: lastMod }));
-                                }
-                                handleData(data);
-                            }
-                        };
-                        fallbackXhr.send();
-                    }
+
+                    OCA.Analytics.currentReportData = OCA.Analytics.Report.Backend.processReceivedData(data);
+                    OCA.Analytics.Report.buildReport();
+                    let refresh = parseInt(OCA.Analytics.currentReportData.options.refresh);
+                    OCA.Analytics.Report.Backend.startRefreshTimer(refresh);
+                }
+                else if (xhr.status === 304 && cachedData) {
+                    // backend confirmed no change → reuse cached data
+                    OCA.Analytics.currentReportData = OCA.Analytics.Report.Backend.processReceivedData(cachedData);
+                    OCA.Analytics.Report.buildReport();
+                    let refresh = parseInt(OCA.Analytics.currentReportData.options.refresh);
+                    OCA.Analytics.Report.Backend.startRefreshTimer(refresh);
                 }
             }
         };
-
         xhr.send();
+    },
+
+    processReceivedData: function (data) {
+        // Do something with the data here
+        try {
+            // Chart.js v4.4.3 changed from xAxes to x. In case the user has old chart options, they need to be corrected
+            let parsedChartOptions = JSON.parse(data.options.chartoptions.replace(/xAxes/g, 'x'));
+            data.options.chartoptions = (parsedChartOptions !== null && typeof parsedChartOptions === 'object') ? parsedChartOptions : {};
+        } catch (e) {
+            data.options.chartoptions = {};
+        }
+
+        try {
+            let parsedDataOptions = JSON.parse(data.options.dataoptions);
+            data.options.dataoptions = (parsedDataOptions !== null && typeof parsedDataOptions === 'object') ? parsedDataOptions : {};
+        } catch (e) {
+            data.options.dataoptions = {};
+        }
+
+        try {
+            let parsedFilterOptions = JSON.parse(data.options.filteroptions);
+            data.options.filteroptions = (parsedFilterOptions !== null && typeof parsedFilterOptions === 'object') ? parsedFilterOptions : {};
+        } catch (e) {
+            data.options.filteroptions = {};
+        }
+
+        try {
+            let parsedTableOptions = JSON.parse(data.options.tableoptions);
+            data.options.tableoptions = (parsedTableOptions !== null && typeof parsedTableOptions === 'object') ? parsedTableOptions : {};
+        } catch (e) {
+            data.options.tableoptions = {};
+        }
+
+        // if the user uses a special time parser (e.g. DD.MM), the data needs to be sorted differently
+        data = OCA.Analytics.Visualization.sortDates(data);
+        data = OCA.Analytics.Visualization.applyTimeAggregation(data);
+        data = OCA.Analytics.Visualization.applyTopN(data);
+
+        return data;
     },
 
     /**

--- a/lib/Controller/ReportController.php
+++ b/lib/Controller/ReportController.php
@@ -101,11 +101,10 @@ class ReportController extends Controller
      * @param int $reportId
      * @return DataResponse
      */
-    public function read(int $reportId)
-    {
-        return new DataResponse($this->ReportService->read($reportId, false));
-    }
-
+	public function read(int $reportId)
+	{
+		return new DataResponse($this->ReportService->read($reportId, false));
+	}
     /**
      * Delete report and all depending objects
      *

--- a/lib/Db/ReportMapper.php
+++ b/lib/Db/ReportMapper.php
@@ -48,6 +48,7 @@ class ReportMapper
             ->addSelect('type')
             ->addSelect('parent')
             ->addSelect('dataset')
+			->addSelect('version')
             ->where($sql->expr()->eq('user_id', $sql->createNamedParameter($this->userId)))
             ->orderBy('parent', 'ASC')
             ->addOrderBy('name', 'ASC');

--- a/lib/Migration/Version5009Date20250816100000.php
+++ b/lib/Migration/Version5009Date20250816100000.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Analytics
+ *
+ * SPDX-FileCopyrightText: 2019-2022 Marcel Scherello
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Analytics\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ * sudo -u www-data php occ migrations:execute analytics 5009Date20250816100000
+ */
+class Version5009Date20250816100000 extends SimpleMigrationStep {
+	public function __construct(
+		private IDBConnection $connection,
+	) {
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('analytics_report');
+		if (!$table->hasColumn('version')) {
+
+			$table->addColumn('version', 'integer', [
+				'notnull' => false,
+				'default' => 0,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/ReportService.php
+++ b/lib/Service/ReportService.php
@@ -83,14 +83,14 @@ class ReportService {
 	public function index(): array {
 		$ownReports = $this->ReportMapper->index();
 		$sharedReports = $this->ShareService->getSharedItems(ShareService::SHARE_ITEM_TYPE_REPORT);
-		$keysToKeep = array('id', 'name', 'dataset', 'favorite', 'parent', 'type', 'isShare', 'shareId');
+		$keysToKeep = array('id', 'name', 'dataset', 'favorite', 'parent', 'type', 'item_type', 'isShare', 'shareId', 'version');
 
 		// get shared reports and remove duplicates
 		$existingIds = array_flip(array_column($ownReports, 'id'));
 		foreach ($sharedReports as $sharedReport) {
 			if (!isset($existingIds[$sharedReport['id']])) {
 				// just keep the necessary fields
-				$ownReports[] = array_intersect_key($sharedReport, array_flip($keysToKeep));
+				$ownReports[] = $sharedReport;
 				$existingIds[$sharedReport['id']] = true;
 			}
 		}
@@ -105,6 +105,11 @@ class ReportService {
 			$ownReport['favorite'] = $hasTag;
 			$ownReport['item_type'] = ShareService::SHARE_ITEM_TYPE_REPORT;
 			$ownReport = $this->VariableService->replaceTextVariables($ownReport);
+		}
+
+		// Final column filter
+		foreach ($ownReports as &$ownReport) {
+			$ownReport = array_intersect_key($ownReport, array_flip($keysToKeep));
 		}
 
 		return $ownReports;

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -33,12 +33,12 @@ class ShareService {
 	/** @var IUserSession */
 	private $userSession;
 	/** @var LoggerInterface */
-        private $logger;
-        /** @var ShareMapper */
-        private $ShareMapper;
-        private $ReportMapper;
-        private $PanoramaMapper;
-        private $secureRandom;
+	private $logger;
+	/** @var ShareMapper */
+	private $ShareMapper;
+	private $ReportMapper;
+	private $PanoramaMapper;
+	private $secureRandom;
 	private $ActivityManager;
 	/** @var IGroupManager */
 	private $groupManager;
@@ -50,9 +50,9 @@ class ShareService {
 		IUserSession    $userSession,
 		LoggerInterface $logger,
 		ShareMapper     $ShareMapper,
-                ReportMapper    $ReportMapper,
-                PanoramaMapper  $PanoramaMapper,
-                ActivityManager $ActivityManager,
+		ReportMapper    $ReportMapper,
+		PanoramaMapper  $PanoramaMapper,
+		ActivityManager $ActivityManager,
 		IGroupManager   $groupManager,
 		ISecureRandom   $secureRandom,
 		IUserManager    $userManager,
@@ -61,8 +61,8 @@ class ShareService {
 		$this->userSession = $userSession;
 		$this->logger = $logger;
 		$this->ShareMapper = $ShareMapper;
-                $this->ReportMapper = $ReportMapper;
-                $this->PanoramaMapper = $PanoramaMapper;
+		$this->ReportMapper = $ReportMapper;
+		$this->PanoramaMapper = $PanoramaMapper;
 		$this->secureRandom = $secureRandom;
 		$this->groupManager = $groupManager;
 		$this->ActivityManager = $ActivityManager;
@@ -197,33 +197,33 @@ class ShareService {
 			}
 		}
 
-                if ($item_type === self::SHARE_ITEM_TYPE_PANORAMA) {
-                        foreach ($reports as $report) {
-                                if ((int)$report['type'] === PanoramaService::REPORT_TYPE_GROUP) {
-                                        $subreport = $this->PanoramaMapper->getPanoramasByGroup($report['id']);
-                                        $subreport = array_map(function ($pano) {
-                                                $pano['isShare'] = self::SHARE_TYPE_GROUP;
-                                                return $pano;
-                                        }, $subreport);
+		if ($item_type === self::SHARE_ITEM_TYPE_PANORAMA) {
+			foreach ($reports as $report) {
+				if ((int)$report['type'] === PanoramaService::REPORT_TYPE_GROUP) {
+					$subreport = $this->PanoramaMapper->getPanoramasByGroup($report['id']);
+					$subreport = array_map(function ($pano) {
+						$pano['isShare'] = self::SHARE_TYPE_GROUP;
+						return $pano;
+					}, $subreport);
 
-                                        $reports = array_merge($reports, $subreport);
-                                }
-                        }
-                } else {
-                        foreach ($reports as $report) {
-                                if ((int)$report['type'] === ReportService::REPORT_TYPE_GROUP) {
-                                        $subreport = $this->ReportMapper->getReportsByGroup($report['id']);
-                                        $subreport = array_map(function ($report) {
-                                                $report['isShare'] = self::SHARE_TYPE_GROUP;
-                                                return $report;
-                                        }, $subreport);
+					$reports = array_merge($reports, $subreport);
+				}
+			}
+		} else {
+			foreach ($reports as $report) {
+				if ((int)$report['type'] === ReportService::REPORT_TYPE_GROUP) {
+					$subreport = $this->ReportMapper->getReportsByGroup($report['id']);
+					$subreport = array_map(function ($report) {
+						$report['isShare'] = self::SHARE_TYPE_GROUP;
+						return $report;
+					}, $subreport);
 
-                                        $reports = array_merge($reports, $subreport);
-                                }
-                        }
-                }
-                return $reports;
-        }
+					$reports = array_merge($reports, $subreport);
+				}
+			}
+		}
+		return $reports;
+	}
 
 	/**
 	 * get metadata of a report, shared with current user


### PR DESCRIPTION
## Summary
- cache report data in local storage keyed by report id or token
- send `If-Modified-Since` header and reuse cached data on 304 responses
- refetch data when the server returns 304 but no cache exists

## Testing
- `node --check js/report.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68982862132c8333b1d27c24f6532bd4