### PR TITLE
feat: bump report version on data changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 - Cache report data in the browser (using ETag & If-None-Match) #535
 - Warn about unsaved changes before leaving a report
 
-### Changed
-- Increment report version when datasets or report settings change
-
 ### Fixed
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Cache report data in the browser (using ETag & If-None-Match) #535
 - Warn about unsaved changes before leaving a report
 
+### Changed
+- Increment report version when datasets or report settings change
+
 ### Fixed
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)
 

--- a/lib/Db/ReportMapper.php
+++ b/lib/Db/ReportMapper.php
@@ -262,7 +262,6 @@ class ReportMapper
         $sql = $this->db->getQueryBuilder();
         $sql->update(self::TABLE_NAME)
             ->set('refresh', $sql->createNamedParameter($refresh))
-            ->set('version', $sql->createFunction('COALESCE(version, 0) + 1'))
             ->where($sql->expr()->eq('user_id', $sql->createNamedParameter($this->userId)))
             ->andWhere($sql->expr()->eq('id', $sql->createNamedParameter($id)));
         $sql->executeStatement();
@@ -281,7 +280,6 @@ class ReportMapper
         $sql = $this->db->getQueryBuilder();
         $sql->update(self::TABLE_NAME)
             ->set('parent', $sql->createNamedParameter($groupId))
-            ->set('version', $sql->createFunction('COALESCE(version, 0) + 1'))
             ->where($sql->expr()->eq('user_id', $sql->createNamedParameter($this->userId)))
             ->andWhere($sql->expr()->eq('id', $sql->createNamedParameter($id)));
         $sql->executeStatement();
@@ -294,7 +292,7 @@ class ReportMapper
         $sql = $this->db->getQueryBuilder();
         $sql->update(self::TABLE_NAME)
             ->set('name', $sql->createNamedParameter($name))
-            ->set('version', $sql->createFunction('COALESCE(version, 0) + 1'))
+			->set('version', $sql->createFunction('COALESCE(version, 0) + 1'))
             ->where($sql->expr()->eq('user_id', $sql->createNamedParameter($this->userId)))
             ->andWhere($sql->expr()->eq('id', $sql->createNamedParameter($id)));
         $sql->executeStatement();

--- a/lib/Db/ReportMapper.php
+++ b/lib/Db/ReportMapper.php
@@ -217,6 +217,7 @@ class ReportMapper
             ->set('dimension1', $sql->createNamedParameter($dimension1))
             ->set('dimension2', $sql->createNamedParameter($dimension2))
             ->set('value', $sql->createNamedParameter($value))
+            ->set('version', $sql->createFunction('COALESCE(version, 0) + 1'))
             ->where($sql->expr()->eq('user_id', $sql->createNamedParameter($this->userId)))
             ->andWhere($sql->expr()->eq('id', $sql->createNamedParameter($id)));
         if ($filteroptions !== null) $sql->set('filteroptions', $sql->createNamedParameter($filteroptions));
@@ -242,6 +243,7 @@ class ReportMapper
             ->set('dataoptions', $sql->createNamedParameter($dataoptions))
             ->set('filteroptions', $sql->createNamedParameter($filteroptions))
             ->set('tableoptions', $sql->createNamedParameter($tableoptions))
+            ->set('version', $sql->createFunction('COALESCE(version, 0) + 1'))
             ->where($sql->expr()->eq('user_id', $sql->createNamedParameter($this->userId)))
             ->andWhere($sql->expr()->eq('id', $sql->createNamedParameter($id)));
         $sql->executeStatement();
@@ -260,6 +262,7 @@ class ReportMapper
         $sql = $this->db->getQueryBuilder();
         $sql->update(self::TABLE_NAME)
             ->set('refresh', $sql->createNamedParameter($refresh))
+            ->set('version', $sql->createFunction('COALESCE(version, 0) + 1'))
             ->where($sql->expr()->eq('user_id', $sql->createNamedParameter($this->userId)))
             ->andWhere($sql->expr()->eq('id', $sql->createNamedParameter($id)));
         $sql->executeStatement();
@@ -278,6 +281,7 @@ class ReportMapper
         $sql = $this->db->getQueryBuilder();
         $sql->update(self::TABLE_NAME)
             ->set('parent', $sql->createNamedParameter($groupId))
+            ->set('version', $sql->createFunction('COALESCE(version, 0) + 1'))
             ->where($sql->expr()->eq('user_id', $sql->createNamedParameter($this->userId)))
             ->andWhere($sql->expr()->eq('id', $sql->createNamedParameter($id)));
         $sql->executeStatement();
@@ -290,6 +294,7 @@ class ReportMapper
         $sql = $this->db->getQueryBuilder();
         $sql->update(self::TABLE_NAME)
             ->set('name', $sql->createNamedParameter($name))
+            ->set('version', $sql->createFunction('COALESCE(version, 0) + 1'))
             ->where($sql->expr()->eq('user_id', $sql->createNamedParameter($this->userId)))
             ->andWhere($sql->expr()->eq('id', $sql->createNamedParameter($id)));
         $sql->executeStatement();
@@ -423,6 +428,22 @@ class ReportMapper
         $result = $statement->fetchAll();
         $statement->closeCursor();
         return $result;
+    }
+
+    /**
+     * increase version for all reports of a dataset
+     * @param int $datasetId
+     * @return bool
+     * @throws Exception
+     */
+    public function increaseVersionByDataset(int $datasetId): bool
+    {
+        $sql = $this->db->getQueryBuilder();
+        $sql->update(self::TABLE_NAME)
+            ->set('version', $sql->createFunction('COALESCE(version, 0) + 1'))
+            ->where($sql->expr()->eq('dataset', $sql->createNamedParameter($datasetId)));
+        $sql->executeStatement();
+        return true;
     }
 
     /**

--- a/lib/Service/DatasetService.php
+++ b/lib/Service/DatasetService.php
@@ -192,24 +192,27 @@ class DatasetService {
 	 * @return bool
 	 * @throws Exception
 	 */
-	public function update(int $datasetId, $name, $subheader, $dimension1, $dimension2, $value, $aiIndex) {
-		$dbUpdate = $this->DatasetMapper->update($datasetId, $name, $subheader, $dimension1, $dimension2, $value, $aiIndex);
+        public function update(int $datasetId, $name, $subheader, $dimension1, $dimension2, $value, $aiIndex) {
+                $dbUpdate = $this->DatasetMapper->update($datasetId, $name, $subheader, $dimension1, $dimension2, $value, $aiIndex);
+               $this->ReportMapper->increaseVersionByDataset($datasetId);
 
-		if ($aiIndex === 1) {
-			$this->provider($datasetId);
-		} else {
-			$this->providerRemove($datasetId);
-		}
-		return $dbUpdate;
-	}
+               if ($aiIndex === 1) {
+                       $this->provider($datasetId);
+               } else {
+                       $this->providerRemove($datasetId);
+               }
+               return $dbUpdate;
+        }
 
 	public function createGroup(int $parent = 0): int {
 		return $this->DatasetMapper->createGroup($this->l10n->t('New'), $parent);
 	}
 
-	public function updateGroup(int $datasetId, int $groupId): bool {
-		return $this->DatasetMapper->updateGroup($datasetId, $groupId);
-	}
+        public function updateGroup(int $datasetId, int $groupId): bool {
+               $result = $this->DatasetMapper->updateGroup($datasetId, $groupId);
+               $this->ReportMapper->increaseVersionByDataset($datasetId);
+               return $result;
+        }
 
 	/**
 	 * rename dataset
@@ -218,12 +221,14 @@ class DatasetService {
 	 * @param string $name
 	 * @return bool
 	 */
-	public function rename(int $datasetId, string $name): bool {
-		if ($this->isOwn($datasetId)) {
-			return $this->DatasetMapper->updateName($datasetId, $name);
-		}
-		return false;
-	}
+        public function rename(int $datasetId, string $name): bool {
+                if ($this->isOwn($datasetId)) {
+                       $result = $this->DatasetMapper->updateName($datasetId, $name);
+                       $this->ReportMapper->increaseVersionByDataset($datasetId);
+                       return $result;
+                }
+                return false;
+        }
 
 	/**
 	 * Export Dataset

--- a/lib/Service/ReportService.php
+++ b/lib/Service/ReportService.php
@@ -83,7 +83,18 @@ class ReportService {
 	public function index(): array {
 		$ownReports = $this->ReportMapper->index();
 		$sharedReports = $this->ShareService->getSharedItems(ShareService::SHARE_ITEM_TYPE_REPORT);
-		$keysToKeep = array('id', 'name', 'dataset', 'favorite', 'parent', 'type', 'item_type', 'isShare', 'shareId', 'version');
+		$keysToKeep = array(
+			'id',
+			'name',
+			'dataset',
+			'favorite',
+			'parent',
+			'type',
+			'item_type',
+			'isShare',
+			'shareId',
+			'version'
+		);
 
 		// get shared reports and remove duplicates
 		$existingIds = array_flip(array_column($ownReports, 'id'));
@@ -368,6 +379,7 @@ class ReportService {
 	 * @return int
 	 * @throws \OCP\Files\NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
+	 * @throws Exception
 	 */
 	public function import(?string $path = null, ?string $raw = null) {
 		if ($path !== '' and $path !== null) {
@@ -531,19 +543,19 @@ class ReportService {
 	/**
 	 * @throws Exception
 	 */
-        public function reportsForDataset($datasetId) {
-                return $this->ReportMapper->reportsForDataset($datasetId);
-        }
+	public function reportsForDataset($datasetId) {
+		return $this->ReportMapper->reportsForDataset($datasetId);
+	}
 
-       /**
-        * increase version for all reports of a dataset
-        * @param int $datasetId
-        * @return bool
-        * @throws Exception
-        */
-       public function increaseVersionByDataset(int $datasetId): bool {
-               return $this->ReportMapper->increaseVersionByDataset($datasetId);
-       }
+	/**
+	 * increase version for all reports of a dataset
+	 * @param int $datasetId
+	 * @return bool
+	 * @throws Exception
+	 */
+	public function increaseVersionByDataset(int $datasetId): bool {
+		return $this->ReportMapper->increaseVersionByDataset($datasetId);
+	}
 
 	private function floatvalue($val) {
 		// if value is a 3 digit comma number with one leading zero like 0,111, it should not go through the 1000 separator removal

--- a/lib/Service/ReportService.php
+++ b/lib/Service/ReportService.php
@@ -531,9 +531,19 @@ class ReportService {
 	/**
 	 * @throws Exception
 	 */
-	public function reportsForDataset($datasetId) {
-		return $this->ReportMapper->reportsForDataset($datasetId);
-	}
+        public function reportsForDataset($datasetId) {
+                return $this->ReportMapper->reportsForDataset($datasetId);
+        }
+
+       /**
+        * increase version for all reports of a dataset
+        * @param int $datasetId
+        * @return bool
+        * @throws Exception
+        */
+       public function increaseVersionByDataset(int $datasetId): bool {
+               return $this->ReportMapper->increaseVersionByDataset($datasetId);
+       }
 
 	private function floatvalue($val) {
 		// if value is a 3 digit comma number with one leading zero like 0,111, it should not go through the 1000 separator removal

--- a/lib/Service/StorageService.php
+++ b/lib/Service/StorageService.php
@@ -103,13 +103,13 @@ class StorageService {
 	 * @throws Exception
 	 */
 	public function update(
-		int    $datasetId,
-			   $dimension1,
-			   $dimension2,
-			   $value,
-			   ?string $user_id = null,
-			   $bulkInsert = null,
-			   $aggregation = null
+		int     $datasetId,
+				$dimension1,
+				$dimension2,
+				$value,
+		?string $user_id = null,
+				$bulkInsert = null,
+				$aggregation = null
 	) {
 		TODO:
 		//dates in both columns
@@ -128,19 +128,19 @@ class StorageService {
 		$dimension1 = $dimension1 === '' ? null : $dimension1;
 		$dimension2 = $dimension2 === '' ? null : $dimension2;
 
-                if ($value !== false) {
-                        try {
-                                $action = $this->StorageMapper->create($datasetId, $dimension1, $dimension2, $value, $user_id, null, $bulkInsert, $aggregation);
-                        } catch (\Exception $e) {
-                                $error = 1;
-                        }
-                        if ($action === 'insert') $insert = 1; elseif ($action === 'update') $update = 1;
-                        if ($action === 'insert' || $action === 'update') {
-                                $this->ReportService->increaseVersionByDataset($datasetId);
-                        }
-                } else {
-                        $error = 1;
-                }
+		if ($value !== false) {
+			try {
+				$action = $this->StorageMapper->create($datasetId, $dimension1, $dimension2, $value, $user_id, null, $bulkInsert, $aggregation);
+			} catch (\Exception $e) {
+				$error = 1;
+			}
+			if ($action === 'insert') $insert = 1; elseif ($action === 'update') $update = 1;
+			if ($action === 'insert' || $action === 'update') {
+				$this->ReportService->increaseVersionByDataset($datasetId);
+			}
+		} else {
+			$error = 1;
+		}
 
 		// get all reports for the dataset and evaluate their thresholds for push notifications
 		if ($error === 0) {
@@ -168,11 +168,11 @@ class StorageService {
 	 * @param string|null $user_id
 	 * @return bool
 	 */
-        public function delete(int $datasetId, $dimension1, $dimension2, ?string $user_id = null) {
-               $result = $this->StorageMapper->delete($datasetId, $dimension1, $dimension2, $user_id);
-               $this->ReportService->increaseVersionByDataset($datasetId);
-               return $result;
-        }
+	public function delete(int $datasetId, $dimension1, $dimension2, ?string $user_id = null) {
+		$result = $this->StorageMapper->delete($datasetId, $dimension1, $dimension2, $user_id);
+		$this->ReportService->increaseVersionByDataset($datasetId);
+		return $result;
+	}
 
 	/**
 	 * Simulate delete data
@@ -197,13 +197,13 @@ class StorageService {
 	 * @return int
 	 * @throws Exception
 	 */
-        public function deleteWithFilter(int $datasetId, $filter) {
-               $deleted = $this->StorageMapper->deleteWithFilter($datasetId, $filter);
-               if ($deleted > 0) {
-                       $this->ReportService->increaseVersionByDataset($datasetId);
-               }
-               return $deleted;
-        }
+	public function deleteWithFilter(int $datasetId, $filter) {
+		$deleted = $this->StorageMapper->deleteWithFilter($datasetId, $filter);
+		if ($deleted > 0) {
+			$this->ReportService->increaseVersionByDataset($datasetId);
+		}
+		return $deleted;
+	}
 
 	/**
 	 * Simulate delete data with variables; used for data deletion jobs

--- a/lib/Service/StorageService.php
+++ b/lib/Service/StorageService.php
@@ -128,16 +128,19 @@ class StorageService {
 		$dimension1 = $dimension1 === '' ? null : $dimension1;
 		$dimension2 = $dimension2 === '' ? null : $dimension2;
 
-		if ($value !== false) {
-			try {
-				$action = $this->StorageMapper->create($datasetId, $dimension1, $dimension2, $value, $user_id, null, $bulkInsert, $aggregation);
-			} catch (\Exception $e) {
-				$error = 1;
-			}
-			if ($action === 'insert') $insert = 1; elseif ($action === 'update') $update = 1;
-		} else {
-			$error = 1;
-		}
+                if ($value !== false) {
+                        try {
+                                $action = $this->StorageMapper->create($datasetId, $dimension1, $dimension2, $value, $user_id, null, $bulkInsert, $aggregation);
+                        } catch (\Exception $e) {
+                                $error = 1;
+                        }
+                        if ($action === 'insert') $insert = 1; elseif ($action === 'update') $update = 1;
+                        if ($action === 'insert' || $action === 'update') {
+                                $this->ReportService->increaseVersionByDataset($datasetId);
+                        }
+                } else {
+                        $error = 1;
+                }
 
 		// get all reports for the dataset and evaluate their thresholds for push notifications
 		if ($error === 0) {
@@ -165,9 +168,11 @@ class StorageService {
 	 * @param string|null $user_id
 	 * @return bool
 	 */
-	public function delete(int $datasetId, $dimension1, $dimension2, ?string $user_id = null) {
-		return $this->StorageMapper->delete($datasetId, $dimension1, $dimension2, $user_id);
-	}
+        public function delete(int $datasetId, $dimension1, $dimension2, ?string $user_id = null) {
+               $result = $this->StorageMapper->delete($datasetId, $dimension1, $dimension2, $user_id);
+               $this->ReportService->increaseVersionByDataset($datasetId);
+               return $result;
+        }
 
 	/**
 	 * Simulate delete data
@@ -192,9 +197,13 @@ class StorageService {
 	 * @return int
 	 * @throws Exception
 	 */
-	public function deleteWithFilter(int $datasetId, $filter) {
-		return $this->StorageMapper->deleteWithFilter($datasetId, $filter);
-	}
+        public function deleteWithFilter(int $datasetId, $filter) {
+               $deleted = $this->StorageMapper->deleteWithFilter($datasetId, $filter);
+               if ($deleted > 0) {
+                       $this->ReportService->increaseVersionByDataset($datasetId);
+               }
+               return $deleted;
+        }
 
 	/**
 	 * Simulate delete data with variables; used for data deletion jobs


### PR DESCRIPTION
## Summary
- raise report version on metadata changes
- increase versions for all reports when underlying dataset data updates or is modified
- document version bumping in changelog

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a5b04d7b3883338e3f28a2a7f00e83