### PR TITLE
Allow selecting columns for time aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)
 - date formatting on all rows
 - Exclude hidden columns from time aggregation options
+- Correct visible dimension mapping for time aggregation
 
 ## 5.8.0 - 2025-07-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Cache report data in the browser (using ETag & If-None-Match) #535
 - Warn about unsaved changes before leaving a report
-- Select specific columns for time aggregation via multi-select list
+- Select specific columns for time aggregation via checkboxes
 
 ### Fixed
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)
 - date formatting on all rows
+- Exclude hidden columns from time aggregation options
 
 ## 5.8.0 - 2025-07-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Cache report data in the browser (using ETag & If-None-Match) #535
 - Warn about unsaved changes before leaving a report
-- Select specific columns for time aggregation via in-row checkboxes
+- Select specific columns for time aggregation via multi-select list
 
 ### Fixed
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Cache report data in the browser (using ETag & If-None-Match) #535
 - Warn about unsaved changes before leaving a report
+- Select specific columns for time aggregation
 
 ### Fixed
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Cache report data in the browser (using ETag & If-None-Match) #535
 - Warn about unsaved changes before leaving a report
-- Select specific columns for time aggregation
+- Select specific columns for time aggregation via in-row checkboxes
 
 ### Fixed
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)

--- a/js/filter.js
+++ b/js/filter.js
@@ -406,11 +406,47 @@ OCA.Analytics.Filter = {
         });
 
         const filterOptions = OCA.Analytics.currentReportData.options.filteroptions;
+
+        const columnsContainer = container.getElementById('timeGroupingColumns');
+        const header = OCA.Analytics.currentReportData.header || [];
+        const selectedCols = filterOptions?.timeAggregation?.columns?.map(Number) || [header.length - 1];
+        header.forEach((name, index) => {
+            const div = document.createElement('div');
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.id = 'timeGroupingColumn' + index;
+            checkbox.name = 'timeGroupingColumn';
+            checkbox.value = index;
+            if (selectedCols.includes(index)) {
+                checkbox.checked = true;
+            }
+            const label = document.createElement('label');
+            label.setAttribute('for', checkbox.id);
+            label.textContent = name;
+            div.appendChild(checkbox);
+            div.appendChild(label);
+            columnsContainer.appendChild(div);
+        });
+
         if (filterOptions && filterOptions.timeAggregation) {
             dimSelect.value = filterOptions.timeAggregation.dimension;
             groupingSelect.value = filterOptions.timeAggregation.grouping;
             modeSelect.value = filterOptions.timeAggregation.mode;
         }
+
+        const updateColumnCheckboxes = () => {
+            const dimIdx = parseInt(dimSelect.value.match(/\d+$/)?.[0], 10) - 1;
+            columnsContainer.querySelectorAll('input[name="timeGroupingColumn"]').forEach(cb => {
+                if (parseInt(cb.value, 10) === dimIdx) {
+                    cb.checked = false;
+                    cb.disabled = true;
+                } else {
+                    cb.disabled = false;
+                }
+            });
+        };
+        updateColumnCheckboxes();
+        dimSelect.addEventListener('change', updateColumnCheckboxes);
 
         OCA.Analytics.Notification.htmlDialogUpdate(
             container,
@@ -433,6 +469,15 @@ OCA.Analytics.Filter = {
         filterOptions.timeAggregation.dimension = document.getElementById('timeGroupingDimension').value;
         filterOptions.timeAggregation.grouping = grouping;
         filterOptions.timeAggregation.mode = document.getElementById('timeGroupingMode').value;
+
+        const selected = [];
+        const colBoxes = document.getElementsByName('timeGroupingColumn');
+        for (let i = 0; i < colBoxes.length; i++) {
+            if (colBoxes[i].checked) {
+                selected.push(parseInt(colBoxes[i].value, 10));
+            }
+        }
+        filterOptions.timeAggregation.columns = selected;
 
         if (grouping === 'none') {
             delete filterOptions.timeAggregation;

--- a/js/filter.js
+++ b/js/filter.js
@@ -411,7 +411,11 @@ OCA.Analytics.Filter = {
         const header = OCA.Analytics.currentReportData.header || [];
         const selectedCols = filterOptions?.timeAggregation?.columns?.map(Number) || [header.length - 1];
         header.forEach((name, index) => {
-            const div = document.createElement('div');
+            const label = document.createElement('label');
+            label.style.whiteSpace = 'nowrap';
+            label.style.marginRight = '10px';
+            label.style.display = 'inline-block';
+
             const checkbox = document.createElement('input');
             checkbox.type = 'checkbox';
             checkbox.id = 'timeGroupingColumn' + index;
@@ -420,12 +424,10 @@ OCA.Analytics.Filter = {
             if (selectedCols.includes(index)) {
                 checkbox.checked = true;
             }
-            const label = document.createElement('label');
-            label.setAttribute('for', checkbox.id);
-            label.textContent = name;
-            div.appendChild(checkbox);
-            div.appendChild(label);
-            columnsContainer.appendChild(div);
+
+            label.appendChild(checkbox);
+            label.appendChild(document.createTextNode(name));
+            columnsContainer.appendChild(label);
         });
 
         if (filterOptions && filterOptions.timeAggregation) {

--- a/js/filter.js
+++ b/js/filter.js
@@ -392,11 +392,13 @@ OCA.Analytics.Filter = {
 
         const dimensions = OCA.Analytics.currentReportData.dimensions;
         const drilldown = filterOptions.drilldown || {};
-        const visibleDims = Object.keys(dimensions).filter(key => !drilldown[key]);
+        const visibleDims = Object.keys(dimensions)
+            .map(Number)
+            .filter(idx => drilldown[idx] === undefined);
         const dimSelect = container.getElementById('timeGroupingDimension');
         dimSelect.innerHTML = '';
-        visibleDims.forEach(key => {
-            dimSelect.options.add(new Option(dimensions[key], key));
+        visibleDims.forEach(idx => {
+            dimSelect.options.add(new Option(dimensions[idx], idx));
         });
 
         const groupingSelect = container.getElementById('timeGroupingGrouping');
@@ -436,7 +438,7 @@ OCA.Analytics.Filter = {
         }
 
         const updateColumnOptions = () => {
-            const dimIdx = visibleDims.indexOf(dimSelect.value);
+            const dimIdx = visibleDims.indexOf(parseInt(dimSelect.value, 10));
             columnsContainer.querySelectorAll('input[type="checkbox"]').forEach(cb => {
                 if (parseInt(cb.value, 10) === dimIdx) {
                     cb.checked = false;

--- a/js/filter.js
+++ b/js/filter.js
@@ -407,17 +407,23 @@ OCA.Analytics.Filter = {
 
         const filterOptions = OCA.Analytics.currentReportData.options.filteroptions;
 
-        const columnsSelect = container.getElementById('timeGroupingColumns');
+        const columnsContainer = container.getElementById('timeGroupingColumns');
         const header = OCA.Analytics.currentReportData.header || [];
         const selectedCols = filterOptions?.timeAggregation?.columns?.map(Number) || [header.length - 1];
         header.forEach((name, index) => {
-            const option = document.createElement('option');
-            option.value = index;
-            option.textContent = name;
+            const label = document.createElement('label');
+            label.style.whiteSpace = 'nowrap';
+            label.style.marginRight = '10px';
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.name = 'timeGroupingColumn';
+            checkbox.value = index;
             if (selectedCols.includes(index)) {
-                option.selected = true;
+                checkbox.checked = true;
             }
-            columnsSelect.appendChild(option);
+            label.appendChild(checkbox);
+            label.appendChild(document.createTextNode(' ' + name));
+            columnsContainer.appendChild(label);
         });
 
         if (filterOptions && filterOptions.timeAggregation) {
@@ -428,12 +434,12 @@ OCA.Analytics.Filter = {
 
         const updateColumnOptions = () => {
             const dimIdx = parseInt(dimSelect.value.match(/\d+$/)?.[0], 10) - 1;
-            Array.from(columnsSelect.options).forEach(opt => {
-                if (parseInt(opt.value, 10) === dimIdx) {
-                    opt.selected = false;
-                    opt.disabled = true;
+            columnsContainer.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+                if (parseInt(cb.value, 10) === dimIdx) {
+                    cb.checked = false;
+                    cb.disabled = true;
                 } else {
-                    opt.disabled = false;
+                    cb.disabled = false;
                 }
             });
         };
@@ -462,10 +468,9 @@ OCA.Analytics.Filter = {
         filterOptions.timeAggregation.grouping = grouping;
         filterOptions.timeAggregation.mode = document.getElementById('timeGroupingMode').value;
 
-        const columnsSelect = document.getElementById('timeGroupingColumns');
-        const selected = Array.from(columnsSelect.options)
-            .filter(opt => opt.selected)
-            .map(opt => parseInt(opt.value, 10));
+        const selected = Array.from(document.getElementsByName('timeGroupingColumn'))
+            .filter(cb => cb.checked)
+            .map(cb => parseInt(cb.value, 10));
         filterOptions.timeAggregation.columns = selected;
 
         if (grouping === 'none') {

--- a/js/filter.js
+++ b/js/filter.js
@@ -407,27 +407,17 @@ OCA.Analytics.Filter = {
 
         const filterOptions = OCA.Analytics.currentReportData.options.filteroptions;
 
-        const columnsContainer = container.getElementById('timeGroupingColumns');
+        const columnsSelect = container.getElementById('timeGroupingColumns');
         const header = OCA.Analytics.currentReportData.header || [];
         const selectedCols = filterOptions?.timeAggregation?.columns?.map(Number) || [header.length - 1];
         header.forEach((name, index) => {
-            const label = document.createElement('label');
-            label.style.whiteSpace = 'nowrap';
-            label.style.marginRight = '10px';
-            label.style.display = 'inline-block';
-
-            const checkbox = document.createElement('input');
-            checkbox.type = 'checkbox';
-            checkbox.id = 'timeGroupingColumn' + index;
-            checkbox.name = 'timeGroupingColumn';
-            checkbox.value = index;
+            const option = document.createElement('option');
+            option.value = index;
+            option.textContent = name;
             if (selectedCols.includes(index)) {
-                checkbox.checked = true;
+                option.selected = true;
             }
-
-            label.appendChild(checkbox);
-            label.appendChild(document.createTextNode(name));
-            columnsContainer.appendChild(label);
+            columnsSelect.appendChild(option);
         });
 
         if (filterOptions && filterOptions.timeAggregation) {
@@ -436,19 +426,19 @@ OCA.Analytics.Filter = {
             modeSelect.value = filterOptions.timeAggregation.mode;
         }
 
-        const updateColumnCheckboxes = () => {
+        const updateColumnOptions = () => {
             const dimIdx = parseInt(dimSelect.value.match(/\d+$/)?.[0], 10) - 1;
-            columnsContainer.querySelectorAll('input[name="timeGroupingColumn"]').forEach(cb => {
-                if (parseInt(cb.value, 10) === dimIdx) {
-                    cb.checked = false;
-                    cb.disabled = true;
+            Array.from(columnsSelect.options).forEach(opt => {
+                if (parseInt(opt.value, 10) === dimIdx) {
+                    opt.selected = false;
+                    opt.disabled = true;
                 } else {
-                    cb.disabled = false;
+                    opt.disabled = false;
                 }
             });
         };
-        updateColumnCheckboxes();
-        dimSelect.addEventListener('change', updateColumnCheckboxes);
+        updateColumnOptions();
+        dimSelect.addEventListener('change', updateColumnOptions);
 
         OCA.Analytics.Notification.htmlDialogUpdate(
             container,
@@ -472,13 +462,10 @@ OCA.Analytics.Filter = {
         filterOptions.timeAggregation.grouping = grouping;
         filterOptions.timeAggregation.mode = document.getElementById('timeGroupingMode').value;
 
-        const selected = [];
-        const colBoxes = document.getElementsByName('timeGroupingColumn');
-        for (let i = 0; i < colBoxes.length; i++) {
-            if (colBoxes[i].checked) {
-                selected.push(parseInt(colBoxes[i].value, 10));
-            }
-        }
+        const columnsSelect = document.getElementById('timeGroupingColumns');
+        const selected = Array.from(columnsSelect.options)
+            .filter(opt => opt.selected)
+            .map(opt => parseInt(opt.value, 10));
         filterOptions.timeAggregation.columns = selected;
 
         if (grouping === 'none') {

--- a/js/filter.js
+++ b/js/filter.js
@@ -388,10 +388,14 @@ OCA.Analytics.Filter = {
 
         const container = document.importNode(document.getElementById('templateTimeAggregationOptions').content, true);
 
+        const filterOptions = OCA.Analytics.currentReportData.options.filteroptions || {};
+
         const dimensions = OCA.Analytics.currentReportData.dimensions;
+        const drilldown = filterOptions.drilldown || {};
+        const visibleDims = Object.keys(dimensions).filter(key => !drilldown[key]);
         const dimSelect = container.getElementById('timeGroupingDimension');
         dimSelect.innerHTML = '';
-        Object.keys(dimensions).forEach(key => {
+        visibleDims.forEach(key => {
             dimSelect.options.add(new Option(dimensions[key], key));
         });
 
@@ -405,11 +409,10 @@ OCA.Analytics.Filter = {
             modeSelect.options.add(new Option(text, value));
         });
 
-        const filterOptions = OCA.Analytics.currentReportData.options.filteroptions;
-
         const columnsContainer = container.getElementById('timeGroupingColumns');
         const header = OCA.Analytics.currentReportData.header || [];
-        const selectedCols = filterOptions?.timeAggregation?.columns?.map(Number) || [header.length - 1];
+        const selectedCols = (filterOptions?.timeAggregation?.columns?.map(Number) || [header.length - 1])
+            .filter(i => i < header.length);
         header.forEach((name, index) => {
             const label = document.createElement('label');
             label.style.whiteSpace = 'nowrap';
@@ -433,7 +436,7 @@ OCA.Analytics.Filter = {
         }
 
         const updateColumnOptions = () => {
-            const dimIdx = parseInt(dimSelect.value.match(/\d+$/)?.[0], 10) - 1;
+            const dimIdx = visibleDims.indexOf(dimSelect.value);
             columnsContainer.querySelectorAll('input[type="checkbox"]').forEach(cb => {
                 if (parseInt(cb.value, 10) === dimIdx) {
                     cb.checked = false;

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -1113,22 +1113,24 @@ OCA.Analytics.Visualization = {
             return data;
         }
 
-        const dimension = parseInt(tg.dimension.match(/\d+$/)?.[0], 10) - 1;
-        if (isNaN(dimension)) {
+        const drilldown = data.options.filteroptions?.drilldown || {};
+        const dimensions = data.dimensions || {};
+        const visibleDims = Object.keys(dimensions).filter(key => !drilldown[key]);
+        const dimension = visibleDims.indexOf(tg.dimension);
+        if (dimension === -1) {
             return data;
         }
-
-        const grouping = tg.grouping;
-        const mode = tg.mode || 'summation';
-        const valueIndices = (tg.columns && tg.columns.length)
-            ? tg.columns.map(c => parseInt(c, 10))
-            : [data.data[0].length - 1];
 
         if (data.data.length === 0) {
             return data;
         }
 
         const rowLength = data.data[0].length;
+        const grouping = tg.grouping;
+        const mode = tg.mode || 'summation';
+        const valueIndices = (tg.columns && tg.columns.length)
+            ? tg.columns.map(c => parseInt(c, 10)).filter(i => i < rowLength)
+            : [rowLength - 1];
         const valueSet = new Set(valueIndices);
         const keyIndices = [];
         for (let i = 0; i < rowLength; i++) {

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -1115,8 +1115,10 @@ OCA.Analytics.Visualization = {
 
         const drilldown = data.options.filteroptions?.drilldown || {};
         const dimensions = data.dimensions || {};
-        const visibleDims = Object.keys(dimensions).filter(key => !drilldown[key]);
-        const dimension = visibleDims.indexOf(tg.dimension);
+        const visibleDims = Object.keys(dimensions)
+            .map(Number)
+            .filter(idx => drilldown[idx] === undefined);
+        const dimension = visibleDims.indexOf(parseInt(tg.dimension, 10));
         if (dimension === -1) {
             return data;
         }

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -181,6 +181,13 @@
                 <select id="timeGroupingMode" class="optionsInput"></select>
             </div>
         </div>
+        <div style="display: table-row;">
+            <div style="display: table-cell; width: 150px;">
+                <label for="timeGroupingColumns"><?php p($l->t('Columns')); ?></label>
+            </div>
+            <div style="display: table-cell; width: 300px;" id="timeGroupingColumns"></div>
+            <div style="display: table-cell; width: 150px;"></div>
+        </div>
     </div>
 </template>
 

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -160,30 +160,32 @@
 <template id="templateTimeAggregationOptions">
     <div class="table" style="display: table;" id="timeGroupingOptionsTable">
         <div style="display: table-row;">
-            <div style="display: table-cell; width: 150px;">
+            <div style="display: table-cell; width: 150px; vertical-align: middle;">
                 <label for="timeGroupingDimension"><?php p($l->t('Time dimension')); ?></label>
             </div>
-            <div style="display: table-cell; width: 150px;">
+            <div style="display: table-cell; width: 150px; vertical-align: middle;">
                 <label for="timeGroupingGrouping"><?php p($l->t('Grouping')); ?></label>
             </div>
-            <div style="display: table-cell; width: 150px;">
+            <div style="display: table-cell; width: 150px; vertical-align: middle;">
                 <label for="timeGroupingMode"><?php p($l->t('Mode')); ?></label>
             </div>
-            <div style="display: table-cell; width: 300px;">
+            <div style="display: table-cell; width: 150px; vertical-align: middle;">
                 <label for="timeGroupingColumns"><?php p($l->t('Columns')); ?></label>
             </div>
         </div>
         <div style="display: table-row;">
-            <div style="display: table-cell; width: 150px;">
+            <div style="display: table-cell; width: 150px; vertical-align: middle;">
                 <select id="timeGroupingDimension" class="optionsInput"></select>
             </div>
-            <div style="display: table-cell; width: 150px;">
+            <div style="display: table-cell; width: 150px; vertical-align: middle;">
                 <select id="timeGroupingGrouping" class="optionsInput"></select>
             </div>
-            <div style="display: table-cell; width: 150px;">
+            <div style="display: table-cell; width: 150px; vertical-align: middle;">
                 <select id="timeGroupingMode" class="optionsInput"></select>
             </div>
-            <div style="display: table-cell; width: 300px;" id="timeGroupingColumns"></div>
+            <div style="display: table-cell; width: 150px; vertical-align: top;">
+                <select id="timeGroupingColumns" class="optionsInput" multiple size="5" style="height: auto;"></select>
+            </div>
         </div>
     </div>
 </template>

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -169,6 +169,9 @@
             <div style="display: table-cell; width: 150px;">
                 <label for="timeGroupingMode"><?php p($l->t('Mode')); ?></label>
             </div>
+            <div style="display: table-cell; width: 300px;">
+                <label for="timeGroupingColumns"><?php p($l->t('Columns')); ?></label>
+            </div>
         </div>
         <div style="display: table-row;">
             <div style="display: table-cell; width: 150px;">
@@ -180,13 +183,7 @@
             <div style="display: table-cell; width: 150px;">
                 <select id="timeGroupingMode" class="optionsInput"></select>
             </div>
-        </div>
-        <div style="display: table-row;">
-            <div style="display: table-cell; width: 150px;">
-                <label for="timeGroupingColumns"><?php p($l->t('Columns')); ?></label>
-            </div>
             <div style="display: table-cell; width: 300px;" id="timeGroupingColumns"></div>
-            <div style="display: table-cell; width: 150px;"></div>
         </div>
     </div>
 </template>

--- a/templates/part.templates.php
+++ b/templates/part.templates.php
@@ -161,30 +161,22 @@
     <div class="table" style="display: table;" id="timeGroupingOptionsTable">
         <div style="display: table-row;">
             <div style="display: table-cell; width: 150px; vertical-align: middle;">
-                <label for="timeGroupingDimension"><?php p($l->t('Time dimension')); ?></label>
-            </div>
-            <div style="display: table-cell; width: 150px; vertical-align: middle;">
-                <label for="timeGroupingGrouping"><?php p($l->t('Grouping')); ?></label>
-            </div>
-            <div style="display: table-cell; width: 150px; vertical-align: middle;">
-                <label for="timeGroupingMode"><?php p($l->t('Mode')); ?></label>
-            </div>
-            <div style="display: table-cell; width: 150px; vertical-align: middle;">
-                <label for="timeGroupingColumns"><?php p($l->t('Columns')); ?></label>
-            </div>
-        </div>
-        <div style="display: table-row;">
-            <div style="display: table-cell; width: 150px; vertical-align: middle;">
+                <label for="timeGroupingDimension"><?php p($l->t('Time dimension')); ?></label><br>
                 <select id="timeGroupingDimension" class="optionsInput"></select>
             </div>
             <div style="display: table-cell; width: 150px; vertical-align: middle;">
+                <label for="timeGroupingGrouping"><?php p($l->t('Grouping')); ?></label><br>
                 <select id="timeGroupingGrouping" class="optionsInput"></select>
             </div>
             <div style="display: table-cell; width: 150px; vertical-align: middle;">
+                <label for="timeGroupingMode"><?php p($l->t('Mode')); ?></label><br>
                 <select id="timeGroupingMode" class="optionsInput"></select>
             </div>
-            <div style="display: table-cell; width: 150px; vertical-align: top;">
-                <select id="timeGroupingColumns" class="optionsInput" multiple size="5" style="height: auto;"></select>
+        </div>
+        <div style="display: table-row;">
+            <div style="display: table-cell; vertical-align: top;">
+                <span><?php p($l->t('Aggregated Columns')); ?></span>
+                <div id="timeGroupingColumns" style="display: inline-flex; flex-wrap: wrap; gap: 10px; margin-left: 10px;"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Add column selection checkboxes to time aggregation dialog
- Aggregate data across user-chosen columns instead of only the last column
- Document new capability in changelog

## Testing
- `node --check js/filter.js`
- `node --check js/visualization.js`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6d2de88483338f6a0db47c74f8db