### PR TITLE
Fix numeric sorting in datasource drilldown aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)
 - date formatting on all rows
 - fix double report execution after wizard close
+- correct drilldown aggregation for numeric dimension indices
 
 ## 5.8.0 - 2025-07-29
 ### Added

--- a/lib/Controller/DatasourceController.php
+++ b/lib/Controller/DatasourceController.php
@@ -302,8 +302,8 @@ class DatasourceController extends Controller {
 		$options = json_decode($filter, true);
 		if (isset($options['drilldown'])) {
 			// Sort the indices in descending order
-			$sortedIndices = array_keys($options['drilldown']);
-			rsort($sortedIndices);
+                        $sortedIndices = array_keys($options['drilldown']);
+                        rsort($sortedIndices, SORT_NUMERIC);
 
 			foreach ($sortedIndices as $removeIndex) {
 				$aggregatedData = [];

--- a/tests/Controller/DatasourceControllerTest.php
+++ b/tests/Controller/DatasourceControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace OCA\Analytics\Tests\Controller;
+
+use OCA\Analytics\Controller\DatasourceController;
+use OCA\Analytics\Tests\Stubs\FakeL10N;
+use PHPUnit\Framework\TestCase;
+
+class DatasourceControllerTest extends TestCase {
+    public function testAggregateDataRemovesColumnsUsingNumericSorting() {
+        $controller = new DatasourceController(
+            'analytics',
+            $this->createMock(\OCP\IRequest::class),
+            $this->createMock(\Psr\Log\LoggerInterface::class),
+            $this->createMock(\OCA\Analytics\Datasource\Github::class),
+            $this->createMock(\OCA\Analytics\Datasource\LocalCsv::class),
+            $this->createMock(\OCA\Analytics\Datasource\Regex::class),
+            $this->createMock(\OCA\Analytics\Datasource\ExternalJson::class),
+            $this->createMock(\OCA\Analytics\Datasource\LocalJson::class),
+            $this->createMock(\OCA\Analytics\Datasource\ExternalCsv::class),
+            $this->createMock(\OCA\Analytics\Datasource\LocalSpreadsheet::class),
+            new FakeL10N(),
+            $this->createMock(\OCP\EventDispatcher\IEventDispatcher::class),
+            $this->createMock(\OCP\IAppConfig::class)
+        );
+
+        $header = [];
+        $row1 = [];
+        $row2 = [];
+        for ($i = 0; $i <= 10; $i++) {
+            $header[] = 'col' . $i;
+            $row1[] = 'r1c' . $i;
+            $row2[] = 'r2c' . $i;
+        }
+        $header[] = 'Value';
+        $row1[] = 1;
+        $row2[] = 2;
+        $data = ['header' => $header, 'data' => [$row1, $row2]];
+
+        $filter = json_encode(['drilldown' => ['2' => true, '10' => true]]);
+        $reflection = new \ReflectionClass(DatasourceController::class);
+        $method = $reflection->getMethod('aggregateData');
+        $method->setAccessible(true);
+        $result = $method->invoke($controller, $data, $filter);
+
+        $this->assertSame('Value', end($result['header']));
+        $this->assertNotContains('col2', $result['header']);
+        $this->assertNotContains('col10', $result['header']);
+        $this->assertCount(10, $result['header']);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure drilldown indices are sorted numerically before column aggregation
- add regression test for numeric index drilldown
- document fix in changelog

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer global require phpunit/phpunit:^9` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b569f1d4c88333a2352d6d24414256