### PR TITLE
Hide menu bar while reports load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Warn about unsaved changes before leaving a report
 
 ### Fixed
+- Hide menu bar and show loading spinner while reports are loading
 - Fix PHP 8.4 deprecation warnings #534 @[robertoschwald](https://github.com/robertoschwald)
 - date formatting on all rows
 - fix double report execution after wizard close

--- a/js/report.js
+++ b/js/report.js
@@ -784,6 +784,7 @@ Object.assign(OCA.Analytics.Report.Backend = {
     getData: function () {
         if (OCA.Analytics.currentXhrRequest) OCA.Analytics.currentXhrRequest.abort();
         OCA.Analytics.Report.resetContentArea();
+        OCA.Analytics.Visualization.showContentByType('loading');
 
         // Build AJAX parameters from filter options
         const ajaxData = ['filteroptions', 'dataoptions', 'chartoptions', 'tableoptions'].reduce((acc, option) => {

--- a/js/visualization.js
+++ b/js/visualization.js
@@ -1341,7 +1341,7 @@ OCA.Analytics.Visualization = {
             OCA.Analytics.currentContentType = type;
         }
         //}
-        if (type === 'intro' || type === 'warning') {
+        if (type === 'intro' || type === 'warning' || type === 'loading') {
             OCA.Analytics.Visualization.hideElement('menuBar');
         } else {
             OCA.Analytics.Visualization.showElement('menuBar');


### PR DESCRIPTION
## Summary
- Hide the menu bar when the loading spinner is shown
- Show loading spinner when report data is reloaded

## Testing
- `./vendor/bin/phpunit --testsuite unit` *(fails: No such file or directory)*
- `npx eslint -c .eslintrc.js js/visualization.js js/report.js` *(fails: config object using unsupported `env` key)*

------
https://chatgpt.com/codex/tasks/task_e_68c596ecb438833383f85c6f023f99fa