### PR TITLE
Migrate controller annotations to attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - Time aggregation on all key figures and not only the last one
+- Replace controller HTTP annotations with PHP attributes
 
 ### Fixed
 - Hide menu bar and show loading spinner while reports are loading

--- a/lib/Controller/DataloadController.php
+++ b/lib/Controller/DataloadController.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\Files\NotFoundException;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 
 class DataloadController extends Controller
 {
@@ -37,12 +38,12 @@ class DataloadController extends Controller
     /**
      * create a new dataload
      *
-     * @NoAdminRequired
      * @param $datasetId
      * @param int $datasourceId
      * @return DataResponse
      * @throws \OCP\DB\Exception
      */
+    #[NoAdminRequired]
     public function create($datasetId, int $datasourceId): DataResponse
     {
         return new DataResponse(['id' => $this->DataloadService->create($datasetId, $datasourceId)]);
@@ -51,11 +52,11 @@ class DataloadController extends Controller
     /**
      * get all data loads for a dataset or report
      *
-     * @NoAdminRequired
      * @param $datasetId
      * @param $reportId
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function read($datasetId): DataResponse
     {
         return new DataResponse(['dataloads' => $this->DataloadService->read($datasetId)]);
@@ -64,13 +65,13 @@ class DataloadController extends Controller
     /**
      * update dataload
      *
-     * @NoAdminRequired
      * @param int $dataloadId
      * @param $name
      * @param $option
      * @param $schedule
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function update(int $dataloadId, $name, $option, $schedule): DataResponse
     {
         return new DataResponse(['update' => $this->DataloadService->update($dataloadId, $name, $option, $schedule)]);
@@ -79,11 +80,11 @@ class DataloadController extends Controller
     /**
      * copy a dataload
      *
-     * @NoAdminRequired
      * @param int $dataloadId
      * @return DataResponse
      * @throws NotFoundException
      */
+    #[NoAdminRequired]
     public function copy(int $dataloadId): DataResponse
     {
         return new DataResponse($this->DataloadService->copy($dataloadId));
@@ -92,10 +93,10 @@ class DataloadController extends Controller
     /**
      * delete a dataload
      *
-     * @NoAdminRequired
      * @param int $dataloadId
      * @return bool
      */
+    #[NoAdminRequired]
     public function delete(int $dataloadId): bool
     {
         return $this->DataloadService->delete($dataloadId);
@@ -104,11 +105,11 @@ class DataloadController extends Controller
     /**
      * simulate a dataload and output its data
      *
-     * @NoAdminRequired
      * @param int $dataloadId
      * @return DataResponse
      * @throws NotFoundException
      */
+    #[NoAdminRequired]
     public function simulate(int $dataloadId): DataResponse
     {
         return new DataResponse($this->DataloadService->getDataFromDatasource($dataloadId));
@@ -117,11 +118,11 @@ class DataloadController extends Controller
     /**
      * execute a dataload from data source and store into dataset
      *
-     * @NoAdminRequired
      * @param int $dataloadId
      * @return DataResponse
      * @throws Exception
      */
+    #[NoAdminRequired]
     public function execute(int $dataloadId): DataResponse
     {
         return new DataResponse($this->DataloadService->execute($dataloadId));
@@ -135,7 +136,6 @@ class DataloadController extends Controller
     /**
      * update data from input form
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $dimension1
      * @param $dimension2
@@ -144,6 +144,7 @@ class DataloadController extends Controller
      * @return DataResponse|NotFoundResponse
      * @throws Exception
      */
+    #[NoAdminRequired]
     public function updateData(int $reportId, $dimension1, $dimension2, $value, bool $isDataset)
     {
         $result = $this->DataloadService->updateData($reportId, $dimension1, $dimension2, $value, $isDataset);
@@ -157,13 +158,13 @@ class DataloadController extends Controller
     /**
      * delete data from input form
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $dimension1
      * @param $dimension2
      * @param bool $isDataset
      * @return DataResponse|NotFoundResponse
      */
+    #[NoAdminRequired]
     public function deleteData(int $reportId, $dimension1, $dimension2, bool $isDataset)
     {
         $result = $this->DataloadService->deleteData($reportId, $dimension1, $dimension2, $isDataset);
@@ -177,13 +178,13 @@ class DataloadController extends Controller
     /**
      * Simulate delete data from input form
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $dimension1
      * @param $dimension2
      * @param bool $isDataset
      * @return DataResponse|NotFoundResponse
      */
+    #[NoAdminRequired]
     public function deleteDataSimulate(int $reportId, $dimension1, $dimension2, bool $isDataset)
     {
         $result = $this->DataloadService->deleteDataSimulate($reportId, $dimension1, $dimension2, $isDataset);
@@ -197,13 +198,13 @@ class DataloadController extends Controller
     /**
      * Import clipboard data
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $import
      * @param bool $isDataset
      * @return DataResponse|NotFoundResponse
      * @throws Exception
      */
+    #[NoAdminRequired]
     public function importClipboard(int $reportId, $import, bool $isDataset)
     {
         $result = $this->DataloadService->importClipboard($reportId, $import, $isDataset);
@@ -217,13 +218,13 @@ class DataloadController extends Controller
     /**
      * Import data into dataset from an internal or external file
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $path
      * @param bool $isDataset
      * @return DataResponse|NotFoundResponse
      * @throws Exception
      */
+    #[NoAdminRequired]
     public function importFile(int $reportId, $path, bool $isDataset)
     {
         $result = $this->DataloadService->importFile($reportId, $path, $isDataset);

--- a/lib/Controller/DatasetController.php
+++ b/lib/Controller/DatasetController.php
@@ -15,6 +15,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\DB\Exception;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 
 class DatasetController extends Controller {
 	private $logger;
@@ -37,9 +38,9 @@ class DatasetController extends Controller {
 	/**
 	 * get all datasets
 	 *
-	 * @NoAdminRequired
 	 * @return DataResponse
 	 */
+	#[NoAdminRequired]
 	public function index() {
 		return new DataResponse($this->DatasetService->index());
 	}
@@ -47,7 +48,6 @@ class DatasetController extends Controller {
 	/**
 	 * create new dataset
 	 *
-	 * @NoAdminRequired
 	 * @param $name
 	 * @param $dimension1
 	 * @param $dimension2
@@ -55,6 +55,7 @@ class DatasetController extends Controller {
 	 * @return int
 	 * @throws \OCP\DB\Exception
 	 */
+	#[NoAdminRequired]
 	public function create($name, $dimension1, $dimension2, $value) {
 		return $this->DatasetService->create($name, $dimension1, $dimension2, $value);
 	}
@@ -62,10 +63,10 @@ class DatasetController extends Controller {
 	/**
 	 * get own dataset details
 	 *
-	 * @NoAdminRequired
 	 * @param int $datasetId
 	 * @return array|bool
 	 */
+	#[NoAdminRequired]
 	public function read(int $datasetId) {
 		return $this->DatasetService->readOwn($datasetId);
 	}
@@ -73,11 +74,11 @@ class DatasetController extends Controller {
 	/**
 	 * Delete Dataset and all depending objects
 	 *
-	 * @NoAdminRequired
 	 * @param int $datasetId
 	 * @return DataResponse
 	 * @throws \OCP\DB\Exception
 	 */
+	#[NoAdminRequired]
 	public function delete(int $datasetId) {
 		if ($this->DatasetService->isOwn($datasetId)) {
 			$reports = $this->ReportService->reportsForDataset($datasetId);
@@ -94,7 +95,6 @@ class DatasetController extends Controller {
 	/**
 	 * get dataset details
 	 *
-	 * @NoAdminRequired
 	 * @param int $datasetId
 	 * @param $name
 	 * @param null $subheader
@@ -105,6 +105,7 @@ class DatasetController extends Controller {
 	 * @return bool
 	 * @throws Exception
 	 */
+        #[NoAdminRequired]
         public function update(
                 int $datasetId,
                         $name,
@@ -120,10 +121,10 @@ class DatasetController extends Controller {
         /**
          * create dataset group
          *
-         * @NoAdminRequired
          * @param int $parent
          * @return int
          */
+        #[NoAdminRequired]
         public function createGroup(int $parent) {
                 return $this->DatasetService->createGroup($parent);
         }
@@ -131,11 +132,11 @@ class DatasetController extends Controller {
         /**
          * update dataset group assignment
          *
-         * @NoAdminRequired
          * @param int $datasetId
          * @param int $groupId
          * @return bool
          */
+        #[NoAdminRequired]
         public function updateGroup(int $datasetId, int $groupId) {
                 return $this->DatasetService->updateGroup($datasetId, $groupId);
         }
@@ -143,11 +144,11 @@ class DatasetController extends Controller {
         /**
          * rename dataset
          *
-         * @NoAdminRequired
          * @param int $datasetId
          * @param string $name
          * @return bool
          */
+        #[NoAdminRequired]
         public function rename(int $datasetId, string $name) {
                 return $this->DatasetService->rename($datasetId, $name);
         }
@@ -155,10 +156,10 @@ class DatasetController extends Controller {
 	/**
 	 * get status of the dataset
 	 *
-	 * @NoAdminRequired
 	 * @param int $datasetId
 	 * @throws \OCP\DB\Exception
 	 */
+	#[NoAdminRequired]
 	public function status(int $datasetId) {
 		return $this->DatasetService->status($datasetId);
 	}
@@ -166,10 +167,10 @@ class DatasetController extends Controller {
 	/**
 	 * Update the context chat provider
 	 *
-	 * @NoAdminRequired
 	 * @param int $datasetId
 	 * @return DataResponse
 	 */
+	#[NoAdminRequired]
 	public function provider(int $datasetId) {
 		if ($this->DatasetService->isOwn($datasetId)) {
 			$this->DatasetService->provider($datasetId);

--- a/lib/Controller/DatasourceController.php
+++ b/lib/Controller/DatasourceController.php
@@ -23,6 +23,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 
 class DatasourceController extends Controller {
 	private $logger;
@@ -81,10 +82,10 @@ class DatasourceController extends Controller {
 	/**
 	 * get all data source ids + names
 	 *
-	 * @NoAdminRequired
 	 * @param int|null $datasourceType
 	 * @return array
 	 */
+	#[NoAdminRequired]
 	public function index(?int $datasourceType = null) {
 		$result = [];
 		$datasourceIndex = $this->getDatasources($datasourceType);
@@ -106,10 +107,10 @@ class DatasourceController extends Controller {
 	/**
 	 * get one data source
 	 *
-	 * @NoAdminRequired
 	 * @param int|null $datasourceType
 	 * @return array
 	 */
+	#[NoAdminRequired]
 	public function indexFiltered(?int $datasourceType = null) {
 		return $this->index($datasourceType);
 	}
@@ -117,9 +118,9 @@ class DatasourceController extends Controller {
 	/**
 	 * get all data source templates
 	 *
-	 * @NoAdminRequired
 	 * @return array
 	 */
+	#[NoAdminRequired]
 	public function getTemplates() {
 		$result = array();
 		foreach ($this->getDatasources() as $key => $class) {
@@ -131,11 +132,11 @@ class DatasourceController extends Controller {
 	/**
      * Get the data from a data source;
 	 *
-	 * @NoAdminRequired
 	 * @param int $datasourceId
 	 * @param $datasetMetadata
 	 * @return array|NotFoundException
 	 */
+	#[NoAdminRequired]
 	public function read(int $datasourceId, $datasetMetadata) {
 		if (!$this->getDatasources()[$datasourceId]) {
 			$result['error'] = $this->l10n->t('Data source not available anymore');
@@ -267,11 +268,11 @@ class DatasourceController extends Controller {
 	/**
 	 * apply the fiven filters to the hole result set
 	 *
-	 * @NoAdminRequired
 	 * @param $data
 	 * @param $filter
 	 * @return array
 	 */
+	#[NoAdminRequired]
 	private function filterData($data, $filter) {
 		$options = json_decode($filter, true);
 		if (isset($options['filter'])) {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -25,6 +25,10 @@ use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 use OCA\Text\Event\LoadEditor;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\UseSession;
 
 /**
  * Controller class for main page.
@@ -78,10 +82,8 @@ class PageController extends Controller
 		$this->appManager = $appManager;
     }
 
-    /**
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function main()
     {
         $params = array();
@@ -127,55 +129,49 @@ class PageController extends Controller
 		return new TemplateResponse($this->appName, 'main', $params);
     }
 
-	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function report()
 	{
 		return $this->main();
 	}
 
-	/**
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function dataset()
     {
 		return $this->main();
     }
 
-    /**
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function panorama()
     {
         return $this->main();
     }
 
     /**
-     * @PublicPage
-     * @NoCSRFRequired
-     * @UseSession
      *
      * @param string $token
      * @param string $password
      * @return RedirectResponse|TemplateResponse
      */
+    #[PublicPage]
+    #[NoCSRFRequired]
+    #[UseSession]
     public function authenticatePassword(string $token, string $password = '')
     {
         return $this->indexPublic($token, $password);
     }
 
     /**
-     * @PublicPage
-     * @UseSession
-     * @NoCSRFRequired
      * @param $token
      * @param string $password
      * @return TemplateResponse|RedirectResponse
      */
+    #[PublicPage]
+    #[UseSession]
+    #[NoCSRFRequired]
     public function indexPublic($token, string $password = '')
     {
         $share = $this->ShareService->getReportByToken($token);
@@ -206,13 +202,13 @@ class PageController extends Controller
     }
 
     /**
-     * @PublicPage
-     * @UseSession
-     * @NoCSRFRequired
      * @param $token
      * @param string $password
      * @return TemplateResponse|RedirectResponse
      */
+    #[PublicPage]
+    #[UseSession]
+    #[NoCSRFRequired]
     public function indexPublicMin($token, string $password = '')
     {
         $share = $this->ShareService->getReportByToken($token);

--- a/lib/Controller/PanoramaController.php
+++ b/lib/Controller/PanoramaController.php
@@ -15,6 +15,7 @@ use OCP\DB\Exception;
 use OCP\IRequest;
 use OCP\PreConditionNotMetException;
 use Psr\Log\LoggerInterface;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 
 class PanoramaController extends Controller
 {
@@ -36,11 +37,11 @@ class PanoramaController extends Controller
     /**
      * get all reports
      *
-     * @NoAdminRequired
      * @return DataResponse
      * @throws Exception
      * @throws PreConditionNotMetException
      */
+    #[NoAdminRequired]
     public function index()
     {
         return new DataResponse($this->PanoramaService->index());
@@ -49,12 +50,12 @@ class PanoramaController extends Controller
     /**
      * create new blank report
      *
-     * @NoAdminRequired
      * @param int $type
      * @param int $parent
      * @return DataResponse
      * @throws Exception
      */
+    #[NoAdminRequired]
     public function create(int $type, int $parent)
     {
         return new DataResponse($this->PanoramaService->create($type, $parent));
@@ -64,10 +65,10 @@ class PanoramaController extends Controller
     /**
      * get own report details
      *
-     * @NoAdminRequired
      * @param int $panoramaId
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function read(int $panoramaId)
     {
         return new DataResponse($this->PanoramaService->read($panoramaId));
@@ -76,10 +77,10 @@ class PanoramaController extends Controller
     /**
      * Delete report and all depending objects
      *
-     * @NoAdminRequired
      * @param int $panoramaId
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function delete(int $panoramaId)
     {
         if ($this->PanoramaService->isOwn($panoramaId)) {
@@ -92,7 +93,6 @@ class PanoramaController extends Controller
     /**
      * get report details
      *
-     * @NoAdminRequired
      * @param int $panoramaId
      * @param $name
      * @param int $type
@@ -101,6 +101,7 @@ class PanoramaController extends Controller
      * @return DataResponse
      * @throws Exception
      */
+    #[NoAdminRequired]
     public function update(int $panoramaId, $name, int $type, int $parent, $pages)
     {
         $pages = json_encode($pages);
@@ -110,10 +111,10 @@ class PanoramaController extends Controller
     /**
      * create panorama group
      *
-     * @NoAdminRequired
      * @param int $parent
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function createGroup(int $parent)
     {
         return new DataResponse($this->PanoramaService->createGroup($parent));
@@ -122,11 +123,11 @@ class PanoramaController extends Controller
     /**
      * update panorama group assignment
      *
-     * @NoAdminRequired
      * @param int $panoramaId
      * @param int $groupId
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function updateGroup(int $panoramaId, int $groupId)
     {
         return new DataResponse($this->PanoramaService->updateGroup($panoramaId, $groupId));
@@ -135,11 +136,11 @@ class PanoramaController extends Controller
     /**
      * rename panorama
      *
-     * @NoAdminRequired
      * @param int $panoramaId
      * @param string $name
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function rename(int $panoramaId, string $name)
     {
         return new DataResponse($this->PanoramaService->rename($panoramaId, $name));
@@ -148,10 +149,10 @@ class PanoramaController extends Controller
     /**
      * get own reports which are marked as favorites
      *
-     * @NoAdminRequired
      * @return DataResponse
      * @throws Exception
      */
+    #[NoAdminRequired]
     public function getOwnFavoriteReports()
     {
         return new DataResponse($this->PanoramaService->getOwnFavoriteReports());
@@ -160,11 +161,11 @@ class PanoramaController extends Controller
     /**
      * set/remove the favorite flag for a report
      *
-     * @NoAdminRequired
      * @param int $panoramaId
      * @param string $favorite
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function setFavorite(int $panoramaId, string $favorite)
     {
         return new DataResponse($this->PanoramaService->setFavorite($panoramaId, $favorite));

--- a/lib/Controller/ReportController.php
+++ b/lib/Controller/ReportController.php
@@ -14,6 +14,8 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\DB\Exception;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 
 class ReportController extends Controller
 {
@@ -35,9 +37,9 @@ class ReportController extends Controller
     /**
      * get all reports
      *
-     * @NoAdminRequired
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function index()
     {
         return new DataResponse($this->ReportService->index());
@@ -46,7 +48,6 @@ class ReportController extends Controller
     /**
      * create new blank report
      *
-     * @NoAdminRequired
      * @param $name
      * @param $subheader
      * @param int $parent
@@ -60,6 +61,7 @@ class ReportController extends Controller
      * @param $value
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function create($name, $subheader, int $parent, int $type, int $dataset, $link, $visualization, $chart, $dimension1, $dimension2, $value, $addReport = null)
     {
         return new DataResponse($this->ReportService->create($name, $subheader, $parent, $type, $dataset, $link, $visualization, $chart, $dimension1, $dimension2, $value, $addReport));
@@ -68,7 +70,6 @@ class ReportController extends Controller
     /**
      * copy an existing report with the current navigation status
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $chartoptions
      * @param $dataoptions
@@ -77,6 +78,7 @@ class ReportController extends Controller
      * @return DataResponse
      * @throws Exception
      */
+    #[NoAdminRequired]
     public function createCopy(int $reportId, $chartoptions, $dataoptions, $filteroptions, $tableoptions)
     {
         return new DataResponse($this->ReportService->createCopy($reportId, $chartoptions, $dataoptions, $filteroptions, $tableoptions));
@@ -85,10 +87,10 @@ class ReportController extends Controller
     /**
      * create new report from file
      *
-     * @NoAdminRequired
      * @param string $file
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function createFromDataFile($file = '')
     {
         return new DataResponse($this->ReportService->createFromDataFile($file));
@@ -97,10 +99,10 @@ class ReportController extends Controller
     /**
      * get own report details
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @return DataResponse
      */
+	#[NoAdminRequired]
 	public function read(int $reportId)
 	{
 		return new DataResponse($this->ReportService->read($reportId, false));
@@ -108,10 +110,10 @@ class ReportController extends Controller
     /**
      * Delete report and all depending objects
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function delete(int $reportId)
     {
         if ($this->ReportService->isOwn($reportId)) {
@@ -124,7 +126,6 @@ class ReportController extends Controller
     /**
      * get report details
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $name
      * @param $subheader
@@ -140,6 +141,7 @@ class ReportController extends Controller
      * @return DataResponse
      * @throws \OCP\DB\Exception
      */
+    #[NoAdminRequired]
     public function update(int $reportId, $name, $subheader, int $parent, $link, $visualization, $chart, $chartoptions, $dataoptions, $dimension1 = null, $dimension2 = null, $value = null)
     {
         return new DataResponse($this->ReportService->update($reportId, $name, $subheader, $parent, $link, $visualization, $chart, $chartoptions, $dataoptions, $dimension1, $dimension2, $value));
@@ -148,7 +150,6 @@ class ReportController extends Controller
     /**
      * update report options
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $chartoptions
      * @param $dataoptions
@@ -157,6 +158,7 @@ class ReportController extends Controller
      * @return DataResponse
      * @throws Exception
      */
+    #[NoAdminRequired]
     public function updateOptions(int $reportId, $chartoptions, $dataoptions, $filteroptions, $tableoptions)
     {
         return new DataResponse($this->ReportService->updateOptions($reportId, $chartoptions, $dataoptions, $filteroptions, $tableoptions));
@@ -165,11 +167,11 @@ class ReportController extends Controller
     /**
      * update report refresh details
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $refresh
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function updateRefresh(int $reportId, $refresh)
     {
         return new DataResponse($this->ReportService->updateRefresh($reportId, $refresh));
@@ -178,11 +180,11 @@ class ReportController extends Controller
     /**
      * update report group assignment (from drag & drop)
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $groupId
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function updateGroup(int $reportId, $groupId)
     {
         return new DataResponse($this->ReportService->updateGroup($reportId, $groupId));
@@ -191,11 +193,11 @@ class ReportController extends Controller
     /**
      * rename report
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param string $name
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function rename(int $reportId, string $name)
     {
         return new DataResponse($this->ReportService->rename($reportId, $name));
@@ -204,9 +206,9 @@ class ReportController extends Controller
     /**
      * get own reports which are marked as favorites
      *
-     * @NoAdminRequired
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function getOwnFavoriteReports()
     {
         return new DataResponse($this->ReportService->getOwnFavoriteReports());
@@ -215,11 +217,11 @@ class ReportController extends Controller
     /**
      * set/remove the favorite flag for a report
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param string $favorite
      * @return DataResponse
      */
+    #[NoAdminRequired]
     public function setFavorite(int $reportId, string $favorite)
     {
         return new DataResponse($this->ReportService->setFavorite($reportId, $favorite));
@@ -228,10 +230,10 @@ class ReportController extends Controller
     /**
      * Export report
      *
-     * @NoCSRFRequired
-     * @NoAdminRequired
      * @param int $reportId
      */
+    #[NoCSRFRequired]
+    #[NoAdminRequired]
     public function export(int $reportId)
     {
         return $this->ReportService->export($reportId);
@@ -240,13 +242,13 @@ class ReportController extends Controller
     /**
      * Import report
      *
-     * @NoAdminRequired
      * @param string|null $path
      * @param string|null $raw
      * @return DataResponse
      * @throws \OCP\Files\NotFoundException
      * @throws \OCP\Files\NotPermittedException
      */
+    #[NoAdminRequired]
     public function import(?string $path = null, ?string $raw = null)
     {
         return new DataResponse($this->ReportService->import($path, $raw));

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\DB\Exception;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 
 class ShareController extends Controller {
 	const SHARE_TYPE_USER = 0;
@@ -48,7 +49,6 @@ class ShareController extends Controller {
 	/**
 	 * create a new share
 	 *
-	 * @NoAdminRequired
 	 * @param $item_type
 	 * @param $item_source
 	 * @param $type
@@ -56,6 +56,7 @@ class ShareController extends Controller {
 	 * @return DataResponse
 	 * @throws Exception
 	 */
+	#[NoAdminRequired]
 	public function create($item_type, $item_source, $type, $user) {
 		if (($item_type === ShareService::SHARE_ITEM_TYPE_REPORT && $this->ReportService->isOwn($item_source))
 		|| ($item_type === ShareService::SHARE_ITEM_TYPE_PANORAMA && $this->PanoramaService->isOwn($item_source))) {
@@ -68,11 +69,11 @@ class ShareController extends Controller {
 	/**
 	 * get all shares for a report
 	 *
-	 * @NoAdminRequired
 	 * @param $item_source
 	 * @return DataResponse
 	 * @throws Exception
 	 */
+	#[NoAdminRequired]
 	public function readReport($item_source) {
 		if ($this->ReportService->isOwn($item_source)) {
 			return new DataResponse($this->ShareService->read(ShareService::SHARE_ITEM_TYPE_REPORT, $item_source));
@@ -84,11 +85,11 @@ class ShareController extends Controller {
 	/**
 	 * get all shares for a panorama
 	 *
-	 * @NoAdminRequired
 	 * @param $item_source
 	 * @return DataResponse
 	 * @throws Exception
 	 */
+	#[NoAdminRequired]
 	public function readPanorama($item_source) {
 		if ($this->PanoramaService->isOwn($item_source)) {
 			return new DataResponse($this->ShareService->read(ShareService::SHARE_ITEM_TYPE_PANORAMA, $item_source));
@@ -100,13 +101,13 @@ class ShareController extends Controller {
 	/**
 	 * update/set share password
 	 *
-	 * @NoAdminRequired
 	 * @param $shareId
 	 * @param null $password
 	 * @param null $canEdit
 	 * @param null $domain
 	 * @return DataResponse
 	 */
+	#[NoAdminRequired]
 	public function update($shareId, $password = null, $canEdit = null, $domain = null) {
 		return new DataResponse($this->ShareService->update($shareId, $password, $canEdit, $domain));
 	}
@@ -114,10 +115,10 @@ class ShareController extends Controller {
 	/**
 	 * delete a share
 	 *
-	 * @NoAdminRequired
 	 * @param $shareId
 	 * @return DataResponse
 	 */
+	#[NoAdminRequired]
 	public function delete($shareId) {
 		return new DataResponse($this->ShareService->delete($shareId));
 	}

--- a/lib/Controller/ThresholdController.php
+++ b/lib/Controller/ThresholdController.php
@@ -12,6 +12,7 @@ use OCA\Analytics\Service\ThresholdService;
 use OCP\AppFramework\Controller;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 
 class ThresholdController extends Controller
 {
@@ -33,10 +34,10 @@ class ThresholdController extends Controller
     /**
      * read all thresholds for a dataset
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @return array
      */
+    #[NoAdminRequired]
     public function read(int $reportId)
     {
         return $this->ThresholdService->readRaw($reportId);
@@ -45,7 +46,6 @@ class ThresholdController extends Controller
 	/**
 	 * create new threshold for dataset
 	 *
-	 * @NoAdminRequired
 	 * @param int $reportId
 	 * @param $dimension
 	 * @param $option
@@ -54,6 +54,7 @@ class ThresholdController extends Controller
 	 * @param $coloring
 	 * @return int
 	 */
+    #[NoAdminRequired]
     public function create(int $reportId, $dimension, $option, $value, int $severity, $coloring)
     {
         return $this->ThresholdService->create($reportId, $dimension, $option, $value, $severity, $coloring);
@@ -62,10 +63,10 @@ class ThresholdController extends Controller
     /**
      * Delete threshold for dataset
      *
-     * @NoAdminRequired
      * @param int $thresholdId
      * @return bool
      */
+    #[NoAdminRequired]
     public function delete(int $thresholdId)
     {
         $this->ThresholdService->delete($thresholdId);
@@ -75,11 +76,11 @@ class ThresholdController extends Controller
     /**
      * Update threshold order
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param array $order
      * @return bool
      */
+    #[NoAdminRequired]
     public function reorder(int $reportId, $order): bool
     {
         if (is_string($order)) {
@@ -92,7 +93,6 @@ class ThresholdController extends Controller
     /**
      * validate threshold
      *
-     * @NoAdminRequired
      * @param int $reportId
      * @param $dimension1
      * @param $dimension2
@@ -100,6 +100,7 @@ class ThresholdController extends Controller
      * @return string
      * @throws \Exception
      */
+    #[NoAdminRequired]
     public function validate(int $reportId, $dimension1, $dimension2, $value)
     {
         return $this->ThresholdService->validate($reportId, $dimension1, $dimension2, $value);

--- a/lib/Controller/WhatsNewController.php
+++ b/lib/Controller/WhatsNewController.php
@@ -18,6 +18,7 @@ use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use Psr\Log\LoggerInterface;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 
 class WhatsNewController extends Controller
 {
@@ -51,9 +52,7 @@ class WhatsNewController extends Controller
         $this->logger = $logger;
     }
 
-    /**
-     * @NoAdminRequired
-     */
+    #[NoAdminRequired]
     public function get(): DataResponse
     {
         $user = $this->userSession->getUser();
@@ -91,11 +90,11 @@ class WhatsNewController extends Controller
     }
 
     /**
-     * @NoAdminRequired
      *
      * @throws \OCP\PreConditionNotMetException
      * @throws DoesNotExistException
      */
+    #[NoAdminRequired]
     public function dismiss(string $version): DataResponse
     {
         $user = $this->userSession->getUser();

--- a/lib/Controller/WizardController.php
+++ b/lib/Controller/WizardController.php
@@ -13,6 +13,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 
 class WizardController extends Controller
 {
@@ -37,11 +38,11 @@ class WizardController extends Controller
 
 
     /**
-     * @NoAdminRequired
      *
      * @return DataResponse
      * @throws \OCP\PreConditionNotMetException
      */
+    #[NoAdminRequired]
     public function dismiss(): DataResponse
     {
         $user = $this->userSession->getUser();


### PR DESCRIPTION
## Summary
- replace deprecated controller annotations with the corresponding PHP attributes across the app controllers
- document the attribute migration in the changelog

## Testing
- for f in $(git diff --name-only | grep '\.php'); do php -l $f; done

------
https://chatgpt.com/codex/tasks/task_e_68ccacc3fb308333a1136fa3ba449934