### PR TITLE
Adjust warning styling for Nextcloud 32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - Time aggregation on all key figures and not only the last one
 - Replace controller HTTP annotations with PHP attributes
+- Update warning indicators to use Nextcloud 32 contrast variables
 
 ### Fixed
 - Hide menu bar and show loading spinner while reports are loading

--- a/css/style.css
+++ b/css/style.css
@@ -15,8 +15,8 @@
 }
 
 .betaFlag {
-    color: var(--color-warning);
-    border: 1px solid var(--color-warning);
+    color: var(--color-text-warning, var(--color-warning));
+    border: 1px solid var(--color-border-warning, var(--color-element-warning, var(--color-warning)));
     border-radius: 16px;
     padding: 0 9px;
 }
@@ -839,7 +839,7 @@ div.dt-container .dt-paging .dt-paging-button {
 }
 
 .indicateImportantField {
-    border: 1px solid var(--color-warning) !important;
+    border: 1px solid var(--color-border-warning, var(--color-element-warning, var(--color-warning))) !important;
 }
 
 .favorite-mark {
@@ -1301,7 +1301,7 @@ div[id^="analytics-content"] .button:not(.analyticsPrimary):hover,
 }
 
 .pageScroll.highlighted {
-    color: var(--color-warning);
+    color: var(--color-text-warning, var(--color-warning));
     opacity: 0.8;
 }
 


### PR DESCRIPTION
## Summary
- update beta flag, important field, and page scroll highlight styles to use Nextcloud 32 warning tokens with legacy fallbacks
- document the styling refresh in the changelog

## Testing
- composer validate *(warnings about missing package metadata remain)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb4e4e75483339bd42d7f38ec0bd3