### PR TITLE
Update filter option handling for BETWEEN case

### DIFF
--- a/lib/Service/VariableService.php
+++ b/lib/Service/VariableService.php
@@ -145,9 +145,10 @@ class VariableService {
 					$parsed = $this->parseFilter($value['value']);
 					if (!$parsed) continue;
 					// overwrite the filter option. Required for quarters => between
-					$filteroptions['filter'][$key]['option'] = $parsed['option'];
-
-
+					if ($parsed['option'] === 'BETWEEN') {
+						$filteroptions['filter'][$key]['option'] = $parsed['option'];
+					}
+					
 					// if a parser is selected in the chart options, it should also be valid here automatically
 					if (isset($reportMetadata['chartoptions'])) {
 						$chartOptions = json_decode($reportMetadata['chartoptions'], true);


### PR DESCRIPTION
Add condition to overwrite filter option only for BETWEEN.

-> Before, the `option` variable was always filled with the value `GT`, which results in wrong sql statments for the filter & delete queries.

Should fix issue https://github.com/Rello/analytics/issues/558

- @Rello : Please review, this works atm, but I do not have a complete overview of the project