### PR TITLE
Harden storage filter column handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - Dark Mode: Settings element does not adapt text color #565
+- Harden filter column handling to block unsupported identifiers
 
 
 ## 6.0.2 - 2025-12-30


### PR DESCRIPTION
### Motivation
- Prevent misuse of filter keys in storage queries by allowlisting allowed columns and avoid injecting arbitrary identifiers into SQL.
- Improve observability by logging blocked unsupported filter columns to detect suspicious inputs.

### Description
- Add `FILTERABLE_COLUMNS` allowlist constant with `dimension1`, `dimension2`, `timestamp`, and `value`.
- Add `getAllowedFilterColumn()` helper that checks the allowlist and logs blocked columns via `logger`.
- Validate filter keys in `read()` and `sqlWhere()` by replacing direct usage of the filter key with the allowed column and skipping unsupported ones, and update SQL expressions to use the validated column.
- Update `CHANGELOG.md` to document the hardening.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4610f4c48333b53a6dee5bf49d78)